### PR TITLE
CI: update CI schedule following KISS principle

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -39,5 +39,3 @@ jobs:
       uses: codecov/codecov-action@v4.0.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-    - name: Test
-      run: go test -short -timeout 50m -v -run='.*Test[^Plugins|Latest|Muzzle].*' github.com/alibaba/opentelemetry-go-auto-instrumentation/test

--- a/.github/workflows/latestdepth.yml
+++ b/.github/workflows/latestdepth.yml
@@ -8,6 +8,9 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  schedule:
+    # daily at 3:24 UTC
+    - cron: '24 3 * * *'
 
 jobs:
 

--- a/.github/workflows/muzzle.yml
+++ b/.github/workflows/muzzle.yml
@@ -8,6 +8,9 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  schedule:
+    # daily at 3:24 UTC
+    - cron: '24 3 * * *'
 
 jobs:
 


### PR DESCRIPTION
As codecov been updated in basic CI job. To avoid an edge case, as go test fail after codecov update.
Considering pipeline as code and try to follow KISS principle.
- remove go test after codecov update.
- adding schedule to keep testing been run daily.
- for each testing, after this PR, in single file. as all Muzzle testing in muzzle.yml