### PR TITLE
docs: update repository name references to loongsuite-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](docs/public/anim-logo.svg)
 
-[![](https://shields.io/badge/-Docs-blue?logo=readthedocs)](https://alibaba.github.io/loongsuite-go-agent/)  &nbsp;
+[![](https://shields.io/badge/-Docs-blue?logo=readthedocs)](https://alibaba.github.io/loongsuite-go/)  &nbsp;
 [![](https://shields.io/badge/-商业版-blue?logo=alibabacloud)](https://help.aliyun.com/zh/arms/application-monitoring/getting-started/monitoring-the-golang-applications) &nbsp;
 
 **Loongsuite Go Agent** provides an automatic solution for Golang applications that want to
@@ -12,18 +12,18 @@ time. Simply adding `otel` prefix to `go build` to get started :rocket:
 
 ### Prebuilt Binaries
 
-- [![Download](https://shields.io/badge/-Linux_AMD64-blue?logo=ubuntu)](https://github.com/alibaba/loongsuite-go-agent/releases/latest/download/otel-linux-amd64)
-- [![Download](https://shields.io/badge/-Linux_ARM64-blue?logo=ubuntu)](https://github.com/alibaba/loongsuite-go-agent/releases/latest/download/otel-linux-arm64)
-- [![Download](https://shields.io/badge/-MacOS_AMD64-blue?logo=apple)](https://github.com/alibaba/loongsuite-go-agent/releases/latest/download/otel-darwin-amd64)
-- [![Download](https://shields.io/badge/-MacOS_ARM64-blue?logo=apple)](https://github.com/alibaba/loongsuite-go-agent/releases/latest/download/otel-darwin-arm64)
-- [![Download](https://shields.io/badge/-Windows_AMD64-blue?logo=wine)](https://github.com/alibaba/loongsuite-go-agent/releases/latest/download/otel-windows-amd64.exe)
+- [![Download](https://shields.io/badge/-Linux_AMD64-blue?logo=ubuntu)](https://github.com/alibaba/loongsuite-go/releases/latest/download/otel-linux-amd64)
+- [![Download](https://shields.io/badge/-Linux_ARM64-blue?logo=ubuntu)](https://github.com/alibaba/loongsuite-go/releases/latest/download/otel-linux-arm64)
+- [![Download](https://shields.io/badge/-MacOS_AMD64-blue?logo=apple)](https://github.com/alibaba/loongsuite-go/releases/latest/download/otel-darwin-amd64)
+- [![Download](https://shields.io/badge/-MacOS_ARM64-blue?logo=apple)](https://github.com/alibaba/loongsuite-go/releases/latest/download/otel-darwin-arm64)
+- [![Download](https://shields.io/badge/-Windows_AMD64-blue?logo=wine)](https://github.com/alibaba/loongsuite-go/releases/latest/download/otel-windows-amd64.exe)
 
 **This is the recommended way to install the tool.**
 
 ### Install via Bash
 For Linux and MacOS users, the following script will install `otel` in `/usr/local/bin/otel` by default:
 ```bash
-$ sudo curl -fsSL https://cdn.jsdelivr.net/gh/alibaba/loongsuite-go-agent@main/install.sh | sudo bash
+$ sudo curl -fsSL https://cdn.jsdelivr.net/gh/alibaba/loongsuite-go@main/install.sh | sudo bash
 ```
 
 ### Build from Source
@@ -56,18 +56,18 @@ The detailed usage of `otel` tool can be found in [**Usage**](./docs/user/config
 > [!NOTE]
 > If you find any compilation failures while `go build` works, it's likely a bug.
 > Please feel free to file a bug
-> at [GitHub Issues](https://github.com/alibaba/loongsuite-go-agent/issues)
+> at [GitHub Issues](https://github.com/alibaba/loongsuite-go/issues)
 > to help us enhance this project.
 
 # Examples
 
-- [demo](https://github.com/alibaba/loongsuite-go-agent/tree/main/example/demo) - End-to-end example with OpenTelemetry tracing and metrics
-- [zap logging](https://github.com/alibaba/loongsuite-go-agent/tree/main/example/log) - Auto-instrumentation for `github.com/uber-go/zap` logging
-- [benchmark](https://github.com/alibaba/loongsuite-go-agent/tree/main/example/benchmark) - Performance testing and overhead measurement
-- [sql injection](https://github.com/alibaba/loongsuite-go-agent/tree/main/example/sqlinject) - Custom code injection for SQL injection detection
-- [nethttp](https://github.com/alibaba/loongsuite-go-agent/tree/main/example/nethttp) - HTTP monitoring with request/response instrumentation
-- [kratos-demo](https://github.com/alibaba/loongsuite-go-agent/tree/main/example/kratos-demo) - Integration with the Kratos framework
-- [kafka-demo](https://github.com/alibaba/loongsuite-go-agent/tree/main/example/kafka-demo) - Kafka Consumer Message monitoring
+- [demo](https://github.com/alibaba/loongsuite-go/tree/main/example/demo) - End-to-end example with OpenTelemetry tracing and metrics
+- [zap logging](https://github.com/alibaba/loongsuite-go/tree/main/example/log) - Auto-instrumentation for `github.com/uber-go/zap` logging
+- [benchmark](https://github.com/alibaba/loongsuite-go/tree/main/example/benchmark) - Performance testing and overhead measurement
+- [sql injection](https://github.com/alibaba/loongsuite-go/tree/main/example/sqlinject) - Custom code injection for SQL injection detection
+- [nethttp](https://github.com/alibaba/loongsuite-go/tree/main/example/nethttp) - HTTP monitoring with request/response instrumentation
+- [kratos-demo](https://github.com/alibaba/loongsuite-go/tree/main/example/kratos-demo) - Integration with the Kratos framework
+- [kafka-demo](https://github.com/alibaba/loongsuite-go/tree/main/example/kafka-demo) - Kafka Consumer Message monitoring
 
 # Supported Libraries
 <details>
@@ -148,4 +148,4 @@ to engage with us.
 
 | DingTalk | Star History |
 | :---: | :---: |
-| <img src="./docs/public/dingtalk.png" height="200" /> | <img src="https://api.star-history.com/svg?repos=alibaba/loongsuite-go-agent&type=Date" height="200" /> |
+| <img src="./docs/public/dingtalk.png" height="200" /> | <img src="https://api.star-history.com/svg?repos=alibaba/loongsuite-go&type=Date" height="200" /> |

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,10 +1,10 @@
-const repoRoot = 'https://github.com/alibaba/loongsuite-go-agent';
+const repoRoot = 'https://github.com/alibaba/loongsuite-go';
 export default {
     lang: 'en-US',
     title: ' ',
     description: 'It provides an automatic solution for Golang applications that want to leverage OpenTelemetry to enable effective observability. No code changes are required in the target application, the instrumentation is done at compile time. Simply adding `otel` prefix to `go build` to get started ', 
     ignoreDeadLinks: true,
-    base: '/loongsuite-go-agent/',
+    base: '/loongsuite-go/',
     locales: {
         root: {
           label: 'English',
@@ -32,9 +32,9 @@ export default {
             {
                 text: 'Other Agents',
                 items: [
-                    { text: 'Go', link: 'https://github.com/alibaba/loongsuite-go-agent' },
+                    { text: 'Go', link: 'https://github.com/alibaba/loongsuite-go' },
                     { text: 'Java', link: 'https://github.com/alibaba/loongsuite-java-agent' },
-                    { text: 'Python', link: 'https://github.com/alibaba/loongsuite-python-agent' },
+                    { text: 'Python', link: 'https://github.com/alibaba/loongsuite-python' },
                 ]
             }
         ],
@@ -79,7 +79,7 @@ export default {
                       { text: 'Instrument Phase', link: '/hacking/instrument' },
                       { text: 'AST Optimization', link: '/hacking/optimize' },
                       { text: 'Debugging', link: '/hacking/debug' },
-                      { text: 'Tool Internal Slides', link: 'https://github.com/alibaba/loongsuite-go-agent/blob/main/docs/otel-alibaba.pdf' },
+                      { text: 'Tool Internal Slides', link: 'https://github.com/alibaba/loongsuite-go/blob/main/docs/otel-alibaba.pdf' },
                     ]
                 },
                 {
@@ -122,7 +122,7 @@ export default {
                       { text: '埋点阶段', link: '/zh/hacking/instrument' },
                       { text: 'AST优化', link: '/zh/hacking/optimize' },
                       { text: '调试', link: '/zh/hacking/debug' },
-                      { text: '工具内幕幻灯片', link: 'https://github.com/alibaba/loongsuite-go-agent/blob/main/docs/otel-alibaba.pdf' },
+                      { text: '工具内幕幻灯片', link: 'https://github.com/alibaba/loongsuite-go/blob/main/docs/otel-alibaba.pdf' },
                     ]
                 },
                 {

--- a/docs/dev/hook.md
+++ b/docs/dev/hook.md
@@ -5,7 +5,7 @@ We need to create a new plugin directory under pkg/rules/ and then write the plu
 package mux
 
 import _ "unsafe"
-import "github.com/alibaba/loongsuite-go-agent/pkg/api"
+import "github.com/alibaba/loongsuite-go/pkg/api"
 import mux "github.com/gorilla/mux"
 
 //go:linkname muxRoute130OnEnter github.com/gorilla/mux.muxRoute130OnEnter

--- a/docs/dev/register.md
+++ b/docs/dev/register.md
@@ -6,10 +6,10 @@ We need to add a JSON file named after the rule, such as nethttp.json, in the to
   "ImportPath": "github.com/gorilla/mux",
   "Function": "setCurrentRoute",
   "OnEnter": "muxRoute130OnEnter",
-  "Path": "github.com/alibaba/loongsuite-go-agent/pkg/rules/mux"
+  "Path": "github.com/alibaba/loongsuite-go/pkg/rules/mux"
 },...]
 ```
 
-Taking `github.com/gorilla/mux` as an example, this entry declares that we want to inject our instrumentation function `muxRoute130OnEnter` at the beginning of the target function `setCurrentRoute`. The instrumentation code is located under the directory `github.com/alibaba/loongsuite-go-agent/pkg/rules/mux`, and the supported versions of mux are `[1.3.0,1.7.4)`.
+Taking `github.com/gorilla/mux` as an example, this entry declares that we want to inject our instrumentation function `muxRoute130OnEnter` at the beginning of the target function `setCurrentRoute`. The instrumentation code is located under the directory `github.com/alibaba/loongsuite-go/pkg/rules/mux`, and the supported versions of mux are `[1.3.0,1.7.4)`.
 
 For more detailed field definitions, please refer to [rule_def.md](rule_def.md).

--- a/docs/dev/test.md
+++ b/docs/dev/test.md
@@ -1,7 +1,7 @@
 # Test the Hook Code
 
 Once you've added a new instrumentation rule according
-to [how-to-add-a-new-rule.md](https://github.com/alibaba/loongsuite-go-agent/blob/main/docs/how-to-add-a-new-rule.md),
+to [how-to-add-a-new-rule.md](https://github.com/alibaba/loongsuite-go/blob/main/docs/how-to-add-a-new-rule.md),
 you need to add tests to verify your rules. `loongsuite-go-agent` provides a convenient way to verify
 your rules.
 
@@ -23,11 +23,11 @@ go 1.22
 
 replace github.com/alibaba/loongsuite-go-agent => ../../../
 
-replace github.com/alibaba/loongsuite-go-agent/test/verifier => ../../../test/verifier
+replace github.com/alibaba/loongsuite-go/test/verifier => ../../../test/verifier
 
 require (
 	// import this dependency to use verifier
-    github.com/alibaba/loongsuite-go-agent/test/verifier v0.0.0-00010101000000-000000000000
+    github.com/alibaba/loongsuite-go/test/verifier v0.0.0-00010101000000-000000000000
 	github.com/redis/go-redis/v9 v9.0.5
 	go.opentelemetry.io/otel v1.30.0
 	go.opentelemetry.io/otel/sdk v1.30.0
@@ -47,7 +47,7 @@ there should be two spans produced by `test_executing_commands.go`, one represen
 represents for the `get` redis operation. You should use the `verifier` to verify the correctness:
 
 ```go
-import "github.com/alibaba/loongsuite-go-agent/test/verifier"
+import "github.com/alibaba/loongsuite-go/test/verifier"
 
 verifier.WaitAndAssertTraces(func (stubs []tracetest.SpanStubs) {
 	verifier.VerifyDbAttributes(stubs[0][0], "set", "", "redis", "", "localhost", "set a b ex 5 ", "set", "")

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,18 +9,18 @@ time. Simply adding `otel` prefix to `go build` to get started :rocket:
 
 ### Prebuilt Binaries
 
-- [![Download](https://shields.io/badge/-Linux_AMD64-blue?logo=ubuntu)](https://github.com/alibaba/loongsuite-go-agent/releases/latest/download/otel-linux-amd64)
-- [![Download](https://shields.io/badge/-Linux_ARM64-blue?logo=ubuntu)](https://github.com/alibaba/loongsuite-go-agent/releases/latest/download/otel-linux-arm64)
-- [![Download](https://shields.io/badge/-MacOS_AMD64-blue?logo=apple)](https://github.com/alibaba/loongsuite-go-agent/releases/latest/download/otel-darwin-amd64)
-- [![Download](https://shields.io/badge/-MacOS_ARM64-blue?logo=apple)](https://github.com/alibaba/loongsuite-go-agent/releases/latest/download/otel-darwin-arm64)
-- [![Download](https://shields.io/badge/-Windows_AMD64-blue?logo=wine)](https://github.com/alibaba/loongsuite-go-agent/releases/latest/download/otel-windows-amd64.exe)
+- [![Download](https://shields.io/badge/-Linux_AMD64-blue?logo=ubuntu)](https://github.com/alibaba/loongsuite-go/releases/latest/download/otel-linux-amd64)
+- [![Download](https://shields.io/badge/-Linux_ARM64-blue?logo=ubuntu)](https://github.com/alibaba/loongsuite-go/releases/latest/download/otel-linux-arm64)
+- [![Download](https://shields.io/badge/-MacOS_AMD64-blue?logo=apple)](https://github.com/alibaba/loongsuite-go/releases/latest/download/otel-darwin-amd64)
+- [![Download](https://shields.io/badge/-MacOS_ARM64-blue?logo=apple)](https://github.com/alibaba/loongsuite-go/releases/latest/download/otel-darwin-arm64)
+- [![Download](https://shields.io/badge/-Windows_AMD64-blue?logo=wine)](https://github.com/alibaba/loongsuite-go/releases/latest/download/otel-windows-amd64.exe)
 
 **This is the recommended way to install the tool.**
 
 ### Install via Bash
 For Linux and MacOS users, the following script will install `otel` in `/usr/local/bin/otel` by default:
 ```bash
-$ sudo curl -fsSL https://cdn.jsdelivr.net/gh/alibaba/loongsuite-go-agent@main/install.sh | sudo bash
+$ sudo curl -fsSL https://cdn.jsdelivr.net/gh/alibaba/loongsuite-go@main/install.sh | sudo bash
 ```
 
 ### Build from Source
@@ -53,18 +53,18 @@ The detailed usage of `otel` tool can be found in [**Usage**](./user/config.md).
 > [!NOTE]
 > If you find any compilation failures while `go build` works, it's likely a bug.
 > Please feel free to file a bug
-> at [GitHub Issues](https://github.com/alibaba/loongsuite-go-agent/issues)
+> at [GitHub Issues](https://github.com/alibaba/loongsuite-go/issues)
 > to help us enhance this project.
 
 # Examples
 
-- [demo](https://github.com/alibaba/loongsuite-go-agent/tree/main/example/demo) - End-to-end example with OpenTelemetry tracing and metrics
-- [zap logging](https://github.com/alibaba/loongsuite-go-agent/tree/main/example/log) - Auto-instrumentation for `github.com/uber-go/zap` logging
-- [benchmark](https://github.com/alibaba/loongsuite-go-agent/tree/main/example/benchmark) - Performance testing and overhead measurement
-- [sql injection](https://github.com/alibaba/loongsuite-go-agent/tree/main/example/sqlinject) - Custom code injection for SQL injection detection
-- [nethttp](https://github.com/alibaba/loongsuite-go-agent/tree/main/example/nethttp) - HTTP monitoring with request/response instrumentation
-- [kratos-demo](https://github.com/alibaba/loongsuite-go-agent/tree/main/example/kratos-demo) - Integration with the Kratos framework
-- [kafka-demo](https://github.com/alibaba/loongsuite-go-agent/tree/main/example/kafka-demo) - Kafka Consumer Message monitoring
+- [demo](https://github.com/alibaba/loongsuite-go/tree/main/example/demo) - End-to-end example with OpenTelemetry tracing and metrics
+- [zap logging](https://github.com/alibaba/loongsuite-go/tree/main/example/log) - Auto-instrumentation for `github.com/uber-go/zap` logging
+- [benchmark](https://github.com/alibaba/loongsuite-go/tree/main/example/benchmark) - Performance testing and overhead measurement
+- [sql injection](https://github.com/alibaba/loongsuite-go/tree/main/example/sqlinject) - Custom code injection for SQL injection detection
+- [nethttp](https://github.com/alibaba/loongsuite-go/tree/main/example/nethttp) - HTTP monitoring with request/response instrumentation
+- [kratos-demo](https://github.com/alibaba/loongsuite-go/tree/main/example/kratos-demo) - Integration with the Kratos framework
+- [kafka-demo](https://github.com/alibaba/loongsuite-go/tree/main/example/kafka-demo) - Kafka Consumer Message monitoring
 
 # Community
 
@@ -74,4 +74,4 @@ to engage with us.
 
 | DingTalk | Star History |
 | :---: | :---: |
-| <img src="./public/dingtalk.png" height="200" /> | <img src="https://api.star-history.com/svg?repos=alibaba/loongsuite-go-agent&type=Date" height="200" /> |
+| <img src="./public/dingtalk.png" height="200" /> | <img src="https://api.star-history.com/svg?repos=alibaba/loongsuite-go&type=Date" height="200" /> |

--- a/docs/zh/dev/hook.md
+++ b/docs/zh/dev/hook.md
@@ -5,7 +5,7 @@
 package mux
 
 import _ "unsafe"
-import "github.com/alibaba/loongsuite-go-agent/pkg/api"
+import "github.com/alibaba/loongsuite-go/pkg/api"
 import mux "github.com/gorilla/mux"
 
 //go:linkname muxRoute130OnEnter github.com/gorilla/mux.muxRoute130OnEnter

--- a/docs/zh/dev/register.md
+++ b/docs/zh/dev/register.md
@@ -6,10 +6,10 @@
   "ImportPath": "github.com/gorilla/mux",
   "Function": "setCurrentRoute",
   "OnEnter": "muxRoute130OnEnter",
-  "Path": "github.com/alibaba/loongsuite-go-agent/pkg/rules/mux"
+  "Path": "github.com/alibaba/loongsuite-go/pkg/rules/mux"
 },...]
 ```
 
-以`github.com/gorilla/mux`为例，这个条目声明了我们想在目标函数`setCurrentRoute`的开头注入我们的埋点函数`muxRoute130OnEnter`。埋点代码位于`github.com/alibaba/loongsuite-go-agent/pkg/rules/mux`目录下，支持的mux版本是`[1.3.0,1.7.4)`。
+以`github.com/gorilla/mux`为例，这个条目声明了我们想在目标函数`setCurrentRoute`的开头注入我们的埋点函数`muxRoute130OnEnter`。埋点代码位于`github.com/alibaba/loongsuite-go/pkg/rules/mux`目录下，支持的mux版本是`[1.3.0,1.7.4)`。
 
 更详细的字段定义，请参考[rule_def.md](rule_def.md)。

--- a/docs/zh/dev/test.md
+++ b/docs/zh/dev/test.md
@@ -1,6 +1,6 @@
 # 测试Hook代码
 
-根据[如何添加新规则.md](https://github.com/alibaba/loongsuite-go-agent/blob/main/docs/how-to-add-a-new-rule.md)添加新的埋点规则后，您需要添加测试来验证您的规则。`loongsuite-go-agent`提供了一种方便的方式来验证您的规则。
+根据[如何添加新规则.md](https://github.com/alibaba/loongsuite-go/blob/main/docs/how-to-add-a-new-rule.md)添加新的埋点规则后，您需要添加测试来验证您的规则。`loongsuite-go-agent`提供了一种方便的方式来验证您的规则。
 
 ## 添加一个通用的插件测试用例
 
@@ -17,11 +17,11 @@ go 1.22
 
 replace github.com/alibaba/loongsuite-go-agent => ../../../
 
-replace github.com/alibaba/loongsuite-go-agent/test/verifier => ../../../test/verifier
+replace github.com/alibaba/loongsuite-go/test/verifier => ../../../test/verifier
 
 require (
 	// 导入此依赖以使用验证器
-    github.com/alibaba/loongsuite-go-agent/test/verifier v0.0.0-00010101000000-000000000000
+    github.com/alibaba/loongsuite-go/test/verifier v0.0.0-00010101000000-000000000000
 	github.com/redis/go-redis/v9 v9.0.5
 	go.opentelemetry.io/otel v1.30.0
 	go.opentelemetry.io/otel/sdk v1.30.0
@@ -37,7 +37,7 @@ require (
 如果您编写的业务代码与规则匹配，则会产生一些遥测数据（如span）。例如，`test_executing_commands.go`应该产生两个span，一个代表`set` redis操作，另一个代表`get` redis操作。您应该使用`verifier`来验证其正确性：
 
 ```go
-import "github.com/alibaba/loongsuite-go-agent/test/verifier"
+import "github.com/alibaba/loongsuite-go/test/verifier"
 
 verifier.WaitAndAssertTraces(func (stubs []tracetest.SpanStubs) {
 	verifier.VerifyDbAttributes(stubs[0][0], "set", "", "redis", "", "localhost", "set a b ex 5 ", "set", "")

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -6,18 +6,18 @@
 
 ### 预编译二进制文件
 
-- [![下载](https://shields.io/badge/-Linux_AMD64-blue?logo=ubuntu)](https://github.com/alibaba/loongsuite-go-agent/releases/latest/download/otel-linux-amd64)
-- [![下载](https://shields.io/badge/-Linux_ARM64-blue?logo=ubuntu)](https://github.com/alibaba/loongsuite-go-agent/releases/latest/download/otel-linux-arm64)
-- [![下载](https://shields.io/badge/-MacOS_AMD64-blue?logo=apple)](https://github.com/alibaba/loongsuite-go-agent/releases/latest/download/otel-darwin-amd64)
-- [![下载](https://shields.io/badge/-MacOS_ARM64-blue?logo=apple)](https://github.com/alibaba/loongsuite-go-agent/releases/latest/download/otel-darwin-arm64)
-- [![下载](https://shields.io/badge/-Windows_AMD64-blue?logo=wine)](https://github.com/alibaba/loongsuite-go-agent/releases/latest/download/otel-windows-amd64.exe)
+- [![下载](https://shields.io/badge/-Linux_AMD64-blue?logo=ubuntu)](https://github.com/alibaba/loongsuite-go/releases/latest/download/otel-linux-amd64)
+- [![下载](https://shields.io/badge/-Linux_ARM64-blue?logo=ubuntu)](https://github.com/alibaba/loongsuite-go/releases/latest/download/otel-linux-arm64)
+- [![下载](https://shields.io/badge/-MacOS_AMD64-blue?logo=apple)](https://github.com/alibaba/loongsuite-go/releases/latest/download/otel-darwin-amd64)
+- [![下载](https://shields.io/badge/-MacOS_ARM64-blue?logo=apple)](https://github.com/alibaba/loongsuite-go/releases/latest/download/otel-darwin-arm64)
+- [![下载](https://shields.io/badge/-Windows_AMD64-blue?logo=wine)](https://github.com/alibaba/loongsuite-go/releases/latest/download/otel-windows-amd64.exe)
 
 **这是安装该工具的推荐方法。**
 
 ### 通过Bash安装
 对于Linux和MacOS用户，以下脚本默认会将`otel`安装在`/usr/local/bin/otel`：
 ```bash
-$ sudo curl -fsSL https://cdn.jsdelivr.net/gh/alibaba/loongsuite-go-agent@main/install.sh | sudo bash
+$ sudo curl -fsSL https://cdn.jsdelivr.net/gh/alibaba/loongsuite-go@main/install.sh | sudo bash
 ```
 
 ### 从源码构建
@@ -49,18 +49,18 @@ $ otel go build -gcflags="-m" cmd/app
 
 > [!NOTE]
 > 如果你在`go build`能正常工作的情况下发现任何编译失败，这很可能是一个bug。
-> 请随时在[GitHub Issues](https://github.com/alibaba/loongsuite-go-agent/issues)上提交一个bug
+> 请随时在[GitHub Issues](https://github.com/alibaba/loongsuite-go/issues)上提交一个bug
 > 来帮助我们改进这个项目。
 
 # 示例
 
-- [demo](https://github.com/alibaba/loongsuite-go-agent/tree/main/example/demo) - 带有OpenTelemetry追踪和指标的端到端示例
-- [zap logging](https://github.com/alibaba/loongsuite-go-agent/tree/main/example/log) - `github.com/uber-go/zap`日志记录的自动埋点
-- [benchmark](https://github.com/alibaba/loongsuite-go-agent/tree/main/example/benchmark) - 性能测试和开销测量
-- [sql injection](https://github.com/alibaba/loongsuite-go-agent/tree/main/example/sqlinject) - 用于SQL注入检测的自定义代码注入
-- [nethttp](https://github.com/alibaba/loongsuite-go-agent/tree/main/example/nethttp) - 带有请求/响应埋点的HTTP监控
-- [kratos-demo](https://github.com/alibaba/loongsuite-go-agent/tree/main/example/kratos-demo) - 与Kratos框架的集成
-- [kafka-demo](https://github.com/alibaba/loongsuite-go-agent/tree/main/example/kafka-demo) - Kafka消息消费流程自定义代码注入
+- [demo](https://github.com/alibaba/loongsuite-go/tree/main/example/demo) - 带有OpenTelemetry追踪和指标的端到端示例
+- [zap logging](https://github.com/alibaba/loongsuite-go/tree/main/example/log) - `github.com/uber-go/zap`日志记录的自动埋点
+- [benchmark](https://github.com/alibaba/loongsuite-go/tree/main/example/benchmark) - 性能测试和开销测量
+- [sql injection](https://github.com/alibaba/loongsuite-go/tree/main/example/sqlinject) - 用于SQL注入检测的自定义代码注入
+- [nethttp](https://github.com/alibaba/loongsuite-go/tree/main/example/nethttp) - 带有请求/响应埋点的HTTP监控
+- [kratos-demo](https://github.com/alibaba/loongsuite-go/tree/main/example/kratos-demo) - 与Kratos框架的集成
+- [kafka-demo](https://github.com/alibaba/loongsuite-go/tree/main/example/kafka-demo) - Kafka消息消费流程自定义代码注入
 
 
 # 社区
@@ -69,4 +69,4 @@ $ otel go build -gcflags="-m" cmd/app
 
 | 钉钉 | Star历史 |
 | :---: | :---: |
-| <img src="../public/dingtalk.png" height="200" /> | <img src="https://api.star-history.com/svg?repos=alibaba/loongsuite-go-agent&type=Date" height="200" /> |
+| <img src="../public/dingtalk.png" height="200" /> | <img src="https://api.star-history.com/svg?repos=alibaba/loongsuite-go&type=Date" height="200" /> |

--- a/example/demo/README.md
+++ b/example/demo/README.md
@@ -4,7 +4,7 @@
 
 ### 1. build agent
 
-Go to the root directory of `loongsuite-go-agent` and execute the following command:
+Go to the root directory of `loongsuite-go` and execute the following command:
 
 ```shell
 make clean && make build

--- a/example/eino/README.md
+++ b/example/eino/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This is a demonstration project showcasing the use of loongsuite-go-agent with the Eino framework.
+This is a demonstration project showcasing the use of LoongSuite Go with the Eino framework.
 
 ## Architecture
 

--- a/example/kratos-demo/README.md
+++ b/example/kratos-demo/README.md
@@ -2,7 +2,7 @@
 
 ## Overview [中文版](./README_CN.md)
 
-This is a demonstration project showcasing loongsuite-go-agent integration with the Kratos framework.
+This is a demonstration project showcasing LoongSuite Go integration with the Kratos framework.
 
 ## Architecture
 
@@ -20,7 +20,7 @@ The demo consists of two services:
 
 ### Observability
 
-The project uses loongsuite-go-agent to export traces and metrics to:
+The project uses LoongSuite Go to export traces and metrics to:
 - **OpenTelemetry Collector**: Data collection and processing
 - **Jaeger**: Distributed tracing
 - **Prometheus**: Metrics storage

--- a/example/kratos-demo/README_CN.md
+++ b/example/kratos-demo/README_CN.md
@@ -2,7 +2,7 @@
 
 ## 项目简介 [English](./README.md)
 
-这是一个在 Kratos 框架环境下使用 loongsuite-go-agent 的演示项目。
+这是一个在 Kratos 框架环境下使用 LoongSuite Go 的演示项目。
 
 ## 架构说明
 
@@ -20,7 +20,7 @@
 
 ### 可观测性
 
-项目使用 loongsuite-go-agent 将链路追踪（Trace）和监控指标（Metric）导出到：
+项目使用 LoongSuite Go 将链路追踪（Trace）和监控指标（Metric）导出到：
 - **OpenTelemetry Collector**: 数据收集和处理
 - **Jaeger**: 分布式链路追踪
 - **Prometheus**: 监控指标存储

--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,7 @@ detect() {
 }
 
 download() {
-    DOWNLOAD_URL="https://github.com/alibaba/loongsuite-go-agent/releases/latest/download/otel-${CURRENT_OS}-${CURRENT_ARCH}"
+    DOWNLOAD_URL="https://github.com/alibaba/loongsuite-go/releases/latest/download/otel-${CURRENT_OS}-${CURRENT_ARCH}"
     EXECUTABLE="otel"
 
     echo "Downloading from $DOWNLOAD_URL"


### PR DESCRIPTION
Align README, docs site config, install script, and example docs with the renamed GitHub repository (alibaba/loongsuite-go).