### PR TITLE
fix(sarama): correct test assertions and topic setup for CI (#700)

### DIFF
--- a/test/ibm-sarama/v1.40.0/test_sync_batch_produce.go
+++ b/test/ibm-sarama/v1.40.0/test_sync_batch_produce.go
@@ -91,7 +91,7 @@ func main() {
 		receiveCount := 0
 		for _, stub := range stubs[0] {
 			for _, attr := range stub.Attributes {
-				if string(attr.Key) == "messaging.operation" {
+				if string(attr.Key) == "messaging.operation.name" {
 					if attr.Value.AsString() == "publish" {
 						publishCount++
 					} else if attr.Value.AsString() == "receive" {

--- a/test/shopify-sarama/v1.22.0/test_sarama_basic.go
+++ b/test/shopify-sarama/v1.22.0/test_sarama_basic.go
@@ -24,6 +24,10 @@ import (
 )
 
 func main() {
+	if err := createTopic(); err != nil {
+		panic(fmt.Sprintf("create topic error: %v", err))
+	}
+
 	producer, err := createSyncProducer()
 	if err != nil {
 		panic(err)

--- a/test/shopify-sarama/v1.22.0/test_sync_batch_produce.go
+++ b/test/shopify-sarama/v1.22.0/test_sync_batch_produce.go
@@ -91,7 +91,7 @@ func main() {
 		receiveCount := 0
 		for _, stub := range stubs[0] {
 			for _, attr := range stub.Attributes {
-				if string(attr.Key) == "messaging.operation" {
+				if string(attr.Key) == "messaging.operation.name" {
 					if attr.Value.AsString() == "publish" {
 						publishCount++
 					} else if attr.Value.AsString() == "receive" {


### PR DESCRIPTION
## Summary

Fixes CI test failures on PR #700 (feat: add IBM/Shopify sarama Kafka auto-instrumentation).

### Root causes

1. **`shopify-sarama-basic-test`** — panic: `failed to create partition consumer: kafka server: Request was for a topic or partition that does not exist on this broker`. The basic test never called `createTopic()` before consuming from a fresh Kafka container (each test spins up its own container). The ibm-sarama basic test and the async/batch tests all call `createTopic()` first; only the shopify basic test was missing it.

2. **`ibm-sarama-sync-batch-produce-test` & `shopify-sarama-sync-batch-produce-test`** — panic: `expected at least 2 publish spans, got 0`. The instrumentation emits the operation type under the semconv v1.30.0 key `messaging.operation.name` (verified via `test/verifier/verifier.go` `VerifyMQPublishAttributes`/`VerifyMQConsumeAttributes`), but the batch tests were counting spans under the legacy `messaging.operation` key, so the count was always 0.

### Changes

- `test/shopify-sarama/v1.22.0/test_sarama_basic.go`: call `createTopic()` at the start of `main()` (mirrors `test_async_produce.go` and the ibm-sarama basic test).
- `test/ibm-sarama/v1.40.0/test_sync_batch_produce.go` and `test/shopify-sarama/v1.22.0/test_sync_batch_produce.go`: assert on `messaging.operation.name` instead of `messaging.operation`.

### Notes

- Could not push directly to `alibaba/loongsuite-go:feat/sarama-instrumentation` from this environment (no write access on the alibaba repo for the configured identities), so opening this draft PR against the PR branch instead. Merge this into `feat/sarama-instrumentation` to update PR #700 and re-run CI.
- Did not run the full local test suite here because the tests require a live Kafka container and the loongsuite-go instrumentation agent; the changes are minimal and match the working pattern in the sibling async/basic tests.

## Test plan

- [ ] Merge into `feat/sarama-instrumentation`
- [ ] Confirm Plugins2 `build (1.24)` and Plugins4 `build (1.24)`/`build (1.25)` pass on PR #700