### PR TITLE
feat(example): add util-genai streaming demo

### DIFF
--- a/example/genai-stream/README.md
+++ b/example/genai-stream/README.md
@@ -1,0 +1,59 @@
+# GenAI Streaming Instrumentation Demo
+
+A focused, standalone demo showing how to instrument a **streaming** OpenAI chat
+completion with the `util-genai` module. Unlike the general `example/genai` demo,
+this one concentrates on the streaming path and the streaming-specific telemetry.
+
+## What This Demo Covers
+
+- Marking a request as streaming via `invocation.Stream` (`gen_ai.request.stream`)
+- Measuring and recording **time to first chunk**
+  (`gen_ai.response.time_to_first_chunk`)
+- Draining the stream token-by-token and printing tokens as they arrive
+- Capturing token usage from the final usage chunk (`StreamOptions.IncludeUsage`)
+- Exporting both **spans** and **metrics** to stdout
+
+## Prerequisites
+
+- Go 1.24+
+- An OpenAI API key (set as an environment variable)
+
+## How to Run
+
+```bash
+export OPENAI_API_KEY="sk-your-api-key-here"
+
+cd example/genai-stream
+go mod tidy
+go run main.go
+```
+
+## Expected Output
+
+1. The model's answer is printed token-by-token as it streams in.
+2. The measured time-to-first-chunk is printed.
+3. A GenAI span (`chat gpt-4o-mini`) and metrics
+   (`gen_ai.client.operation.duration`, `gen_ai.client.token.usage`) are printed
+   to stdout as JSON.
+
+The span includes streaming attributes such as:
+
+```json
+{
+  "Key": "gen_ai.request.stream",
+  "Value": { "Type": "BOOL", "Value": true }
+},
+{
+  "Key": "gen_ai.response.time_to_first_chunk",
+  "Value": { "Type": "FLOAT64", "Value": 0.342 }
+}
+```
+
+## Project Structure
+
+```
+example/genai-stream/
+├── go.mod      # Module definition with local replace directive
+├── main.go     # Streaming demo application
+└── README.md   # This file
+```

--- a/example/genai-stream/go.mod
+++ b/example/genai-stream/go.mod
@@ -1,0 +1,26 @@
+module github.com/alibaba/loongsuite-go/example/genai-stream
+
+go 1.24.0
+
+require (
+	github.com/alibaba/loongsuite-go/util-genai v0.0.0-00010101000000-000000000000
+	github.com/sashabaranov/go-openai v1.36.1
+	go.opentelemetry.io/otel v1.39.0
+	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.39.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.39.0
+	go.opentelemetry.io/otel/sdk v1.39.0
+	go.opentelemetry.io/otel/sdk/metric v1.39.0
+)
+
+require (
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/otel/metric v1.39.0 // indirect
+	go.opentelemetry.io/otel/trace v1.39.0 // indirect
+	golang.org/x/sys v0.39.0 // indirect
+)
+
+replace github.com/alibaba/loongsuite-go/util-genai => ../../util-genai

--- a/example/genai-stream/main.go
+++ b/example/genai-stream/main.go
@@ -1,0 +1,209 @@
+// Copyright (c) 2024 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main is a focused demo of instrumenting a *streaming* OpenAI chat
+// completion with the util-genai module. It highlights the streaming-specific
+// telemetry: gen_ai.request.stream and gen_ai.response.time_to_first_chunk,
+// exported to stdout as both spans and metrics.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"time"
+
+	utilgenai "github.com/alibaba/loongsuite-go/util-genai"
+	openai "github.com/sashabaranov/go-openai"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+// initTelemetry wires up an OpenTelemetry TracerProvider and MeterProvider,
+// both exporting to stdout so the streaming spans and metrics are visible.
+func initTelemetry() (*sdktrace.TracerProvider, *metric.MeterProvider, error) {
+	res, err := resource.New(context.Background(),
+		resource.WithAttributes(
+			semconv.ServiceNameKey.String("genai-stream-demo"),
+			semconv.ServiceVersionKey.String("0.1.0"),
+		),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create resource: %w", err)
+	}
+
+	traceExporter, err := stdouttrace.New(stdouttrace.WithPrettyPrint())
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create trace exporter: %w", err)
+	}
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(traceExporter),
+		sdktrace.WithResource(res),
+	)
+	otel.SetTracerProvider(tp)
+
+	metricExporter, err := stdoutmetric.New(stdoutmetric.WithPrettyPrint())
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create metric exporter: %w", err)
+	}
+	mp := metric.NewMeterProvider(
+		metric.WithReader(metric.NewPeriodicReader(metricExporter)),
+		metric.WithResource(res),
+	)
+	otel.SetMeterProvider(mp)
+
+	return tp, mp, nil
+}
+
+func main() {
+	tp, mp, err := initTelemetry()
+	if err != nil {
+		log.Fatalf("Failed to initialize telemetry: %v", err)
+	}
+	defer func() {
+		if err := tp.Shutdown(context.Background()); err != nil {
+			log.Printf("Error shutting down tracer provider: %v", err)
+		}
+		if err := mp.Shutdown(context.Background()); err != nil {
+			log.Printf("Error shutting down meter provider: %v", err)
+		}
+	}()
+
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		log.Fatal("OPENAI_API_KEY environment variable is required")
+	}
+	client := openai.NewClient(apiKey)
+
+	// Build a handler that emits both spans and metrics for this invocation.
+	handler := utilgenai.NewTelemetryHandler(
+		utilgenai.WithTracerProvider(tp),
+		utilgenai.WithMeterProvider(mp),
+	)
+
+	fmt.Println("=== Streaming Chat Completion Demo ===")
+	if err := streamChat(context.Background(), client, handler); err != nil {
+		log.Fatalf("streaming demo failed: %v", err)
+	}
+	fmt.Println("\n=== Demo completed. Spans and metrics printed above. ===")
+}
+
+// streamChat instruments a streaming OpenAI chat completion. It records the
+// streaming flag and the time-to-first-chunk, prints tokens as they arrive,
+// and finalizes the span once the stream is fully drained.
+func streamChat(ctx context.Context, client *openai.Client, handler *utilgenai.TelemetryHandler) error {
+	const model = openai.GPT4oMini
+	const prompt = "Count from 1 to 5 with a brief description of each number."
+
+	// Describe the invocation. Setting Stream marks gen_ai.request.stream=true.
+	invocation := utilgenai.NewLLMInvocation(model)
+	invocation.Provider = "openai"
+	invocation.OperationName = utilgenai.OperationChat
+	streaming := true
+	invocation.Stream = &streaming
+	invocation.ConversationID = "conv_stream_demo"
+	invocation.InputMessages = []utilgenai.InputMessage{
+		{
+			Role:  "user",
+			Parts: []utilgenai.MessagePart{utilgenai.Text{Content: prompt}},
+		},
+	}
+
+	// Open the span before the network call so latency is captured accurately.
+	ctx = handler.StartLLM(ctx, invocation)
+
+	stream, err := client.CreateChatCompletionStream(ctx, openai.ChatCompletionRequest{
+		Model:    model,
+		Messages: []openai.ChatCompletionMessage{{Role: openai.ChatMessageRoleUser, Content: prompt}},
+		// Ask the API to include usage stats in the final streamed chunk.
+		StreamOptions: &openai.StreamOptions{IncludeUsage: true},
+	})
+	if err != nil {
+		handler.FailLLM(invocation, &utilgenai.Error{Message: err.Error(), Type: "APIError"})
+		return fmt.Errorf("create stream: %w", err)
+	}
+	defer stream.Close()
+
+	var (
+		fullContent  string
+		finishReason openai.FinishReason
+		firstChunk   = true
+		streamStart  = time.Now()
+	)
+
+	fmt.Print("Streamed response: ")
+	for {
+		resp, recvErr := stream.Recv()
+		if errors.Is(recvErr, io.EOF) {
+			break
+		}
+		if recvErr != nil {
+			handler.FailLLM(invocation, &utilgenai.Error{Message: recvErr.Error(), Type: "StreamError"})
+			return fmt.Errorf("stream recv: %w", recvErr)
+		}
+
+		// Record time-to-first-chunk once, on the first token we see.
+		if firstChunk {
+			ttfc := time.Since(streamStart).Seconds()
+			invocation.TimeToFirstChunk = &ttfc
+			firstChunk = false
+		}
+
+		// The usage-only final chunk carries no choices.
+		if resp.Usage != nil {
+			inTok := resp.Usage.PromptTokens
+			outTok := resp.Usage.CompletionTokens
+			invocation.InputTokens = &inTok
+			invocation.OutputTokens = &outTok
+		}
+		if len(resp.Choices) > 0 {
+			delta := resp.Choices[0].Delta.Content
+			fullContent += delta
+			fmt.Print(delta) // print token-by-token to show real streaming
+			if resp.Choices[0].FinishReason != "" {
+				finishReason = resp.Choices[0].FinishReason
+			}
+		}
+		if resp.ID != "" {
+			invocation.ResponseID = resp.ID
+		}
+		if resp.Model != "" {
+			invocation.ResponseModelName = resp.Model
+		}
+	}
+	fmt.Println()
+
+	// Populate the aggregated response and close the span successfully.
+	invocation.OutputMessages = []utilgenai.OutputMessage{
+		{
+			Role:         "assistant",
+			Parts:        []utilgenai.MessagePart{utilgenai.Text{Content: fullContent}},
+			FinishReason: utilgenai.FinishReason(finishReason),
+		},
+	}
+	handler.StopLLM(invocation)
+
+	if invocation.TimeToFirstChunk != nil {
+		fmt.Printf("Time to first chunk: %.3fs\n", *invocation.TimeToFirstChunk)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add a standalone runnable example under `example/genai-stream` focused on instrumenting a streaming OpenAI chat completion with `util-genai`.
- Records `gen_ai.request.stream` and `gen_ai.response.time_to_first_chunk`, prints tokens as they arrive, and captures token usage from the final usage chunk.
- Exports both spans and metrics to stdout.

## Test plan
- [ ] `cd example/genai-stream && go build ./...`
- [ ] `go vet ./...`
- [ ] `OPENAI_API_KEY=... go run main.go` prints a token-by-token streamed response plus spans/metrics