### PR TITLE
docs(util-genai): link runnable examples in README

### DIFF
--- a/util-genai/README.md
+++ b/util-genai/README.md
@@ -303,6 +303,13 @@ This package automatically records the following metrics:
 - `gen_ai.client.operation.duration`: Duration of GenAI client operations (histogram)
 - `gen_ai.client.token.usage`: Token usage for input and output (histogram)
 
+## Examples
+
+Complete runnable examples are available:
+
+- [`example/genai`](../example/genai): a comprehensive demo covering chat completion, streaming chat completion, and embedding instrumentation.
+- [`example/genai-stream`](../example/genai-stream): a streaming-focused demo highlighting streaming-specific telemetry (`gen_ai.request.stream`, `gen_ai.response.time_to_first_chunk`), exporting both spans and metrics to stdout.
+
 ## References
 
 - [OpenTelemetry GenAI Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/README.md)

--- a/util-genai/README_CN.md
+++ b/util-genai/README_CN.md
@@ -298,6 +298,13 @@ handler := utilgenai.NewTelemetryHandler(
 - `gen_ai.client.token.usage`：输入和输出的 token 使用量（直方图）
 - `gen_ai.client.operation.time_to_first_chunk`：流式响应中接收到首个 chunk 的耗时（直方图）
 
+## 示例
+
+以下是可直接运行的完整示例：
+
+- [`example/genai`](../example/genai)：综合示例，演示 chat completion、流式 chat completion 以及 embedding 的埋点方式。
+- [`example/genai-stream`](../example/genai-stream)：流式专项示例，聚焦流式相关遥测（`gen_ai.request.stream`、`gen_ai.response.time_to_first_chunk`），并将 spans 和 metrics 导出到 stdout。
+
 ## 参考资料
 
 - [OpenTelemetry GenAI 语义约定](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/README.md)


### PR DESCRIPTION
## Summary

Adds an "Examples" / "示例" section to both `util-genai/README.md` and `util-genai/README_CN.md`, linking to the runnable examples in `example/genai` and `example/genai-stream`.

This is a follow-up to #711, which added the streaming mode guide and the Chinese README but merged before this example-links change landed.