### PR TITLE
feat(example): add default resource attributes to genai demos

### DIFF
--- a/example/genai-demo/genai-stream/main.go
+++ b/example/genai-demo/genai-stream/main.go
@@ -30,6 +30,7 @@ import (
 	utilgenai "github.com/alibaba/loongsuite-go/util-genai"
 	openai "github.com/sashabaranov/go-openai"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/sdk/metric"
@@ -45,6 +46,10 @@ func initTelemetry() (*sdktrace.TracerProvider, *metric.MeterProvider, error) {
 		resource.WithAttributes(
 			semconv.ServiceNameKey.String("genai-stream-demo"),
 			semconv.ServiceVersionKey.String("0.1.0"),
+			// Default resource attributes, added in code so no
+			// OTEL_RESOURCE_ATTRIBUTES export is required to run the demo.
+			attribute.String("deployment.environment", "dev"),
+			attribute.String("team", "genai"),
 		),
 	)
 	if err != nil {

--- a/example/genai-demo/genai/main.go
+++ b/example/genai-demo/genai/main.go
@@ -28,6 +28,7 @@ import (
 	utilgenai "github.com/alibaba/loongsuite-go/util-genai"
 	openai "github.com/sashabaranov/go-openai"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -48,6 +49,10 @@ func initTracer() (*sdktrace.TracerProvider, error) {
 		resource.WithAttributes(
 			semconv.ServiceNameKey.String("genai-demo"),
 			semconv.ServiceVersionKey.String("0.1.0"),
+			// Default resource attributes, added in code so no
+			// OTEL_RESOURCE_ATTRIBUTES export is required to run the demo.
+			attribute.String("deployment.environment", "dev"),
+			attribute.String("team", "genai"),
 		),
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary

Add default OpenTelemetry resource attributes (`deployment.environment=dev`, `team=genai`) directly in code for the `genai` and `genai-stream` examples, so the demos carry these attributes without requiring an `OTEL_RESOURCE_ATTRIBUTES` export.

Both examples build cleanly (`go build ./...`, Go 1.24).