### PR TITLE
fix: separate HTTP client transport errors from response status attributes

### DIFF
--- a/pkg/inst-api-semconv/instrumenter/http/http_attrs_extractor.go
+++ b/pkg/inst-api-semconv/instrumenter/http/http_attrs_extractor.go
@@ -22,6 +22,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.opentelemetry.io/otel/trace"
+	"strconv"
 	"strings"
 )
 
@@ -67,6 +68,10 @@ type HttpClientAttrsExtractor[REQUEST any, RESPONSE any, GETTER1 HttpClientAttrs
 	NetworkExtractor net.NetworkAttrsExtractor[REQUEST, RESPONSE, GETTER2]
 }
 
+type httpClientResponseResolver[REQUEST any, RESPONSE any] interface {
+	HasHttpResponse(request REQUEST, response RESPONSE, err error) bool
+}
+
 func (h *HttpClientAttrsExtractor[REQUEST, RESPONSE, GETTER1, GETTER2]) OnStart(attributes []attribute.KeyValue, parentContext context.Context, request REQUEST) ([]attribute.KeyValue, context.Context) {
 	attributes, parentContext = h.Base.OnStart(attributes, parentContext, request)
 	attributes, parentContext = h.NetworkExtractor.OnStart(attributes, parentContext, request)
@@ -89,7 +94,37 @@ func (h *HttpClientAttrsExtractor[REQUEST, RESPONSE, GETTER1, GETTER2]) OnStart(
 }
 
 func (h *HttpClientAttrsExtractor[REQUEST, RESPONSE, GETTER1, GETTER2]) OnEnd(attributes []attribute.KeyValue, context context.Context, request REQUEST, response RESPONSE, err error) ([]attribute.KeyValue, context.Context) {
-	attributes, context = h.Base.OnEnd(attributes, context, request, response, err)
+	getter := h.Base.HttpGetter
+	hasResponse := err == nil
+	if resolver, ok := any(getter).(httpClientResponseResolver[REQUEST, RESPONSE]); ok {
+		hasResponse = resolver.HasHttpResponse(request, response, err)
+	}
+	protocolName := h.Base.NetGetter.GetNetworkProtocolName(request, response)
+	protocolVersion := h.Base.NetGetter.GetNetworkProtocolVersion(request, response)
+	attributes = append(attributes, attribute.KeyValue{
+		Key:   semconv.NetworkProtocolNameKey,
+		Value: attribute.StringValue(protocolName),
+	}, attribute.KeyValue{
+		Key:   semconv.NetworkProtocolVersionKey,
+		Value: attribute.StringValue(protocolVersion),
+	})
+	if hasResponse {
+		statusCode := getter.GetHttpResponseStatusCode(request, response, err)
+		attributes = append(attributes, attribute.KeyValue{
+			Key:   semconv.HTTPResponseStatusCodeKey,
+			Value: attribute.IntValue(statusCode),
+		})
+	}
+	errorType := getter.GetErrorType(request, response, err)
+	if errorType == "" && err != nil && !hasResponse {
+		errorType = NormalizeHTTPClientErrorType(err)
+	}
+	if errorType != "" {
+		attributes = append(attributes, attribute.KeyValue{
+			Key:   semconv.ErrorTypeKey,
+			Value: attribute.StringValue(errorType),
+		})
+	}
 	attributes, context = h.NetworkExtractor.OnEnd(attributes, context, request, response, err)
 	if h.Base.AttributesFilter != nil {
 		attributes = h.Base.AttributesFilter(attributes)
@@ -131,6 +166,24 @@ func (h *HttpServerAttrsExtractor[REQUEST, RESPONSE, GETTER1, GETTER2, GETTER3])
 	attributes, context = h.Base.OnEnd(attributes, context, request, response, err)
 	attributes, context = h.UrlExtractor.OnEnd(attributes, context, request, response, err)
 	attributes, context = h.NetworkExtractor.OnEnd(attributes, context, request, response, err)
+
+	statusCode := h.Base.HttpGetter.GetHttpResponseStatusCode(request, response, err)
+	if statusCode >= 500 || statusCode < 100 {
+		hasErrorType := false
+		for _, attr := range attributes {
+			if attr.Key == semconv.ErrorTypeKey {
+				hasErrorType = true
+				break
+			}
+		}
+		if !hasErrorType {
+			attributes = append(attributes, attribute.KeyValue{
+				Key:   semconv.ErrorTypeKey,
+				Value: attribute.StringValue(strconv.Itoa(statusCode)),
+			})
+		}
+	}
+
 	span := trace.SpanFromContext(context)
 	localRootSpan, ok := span.(sdktrace.ReadOnlySpan)
 	if ok && span.IsRecording() {

--- a/pkg/inst-api-semconv/instrumenter/http/http_attrs_extractor.go
+++ b/pkg/inst-api-semconv/instrumenter/http/http_attrs_extractor.go
@@ -108,17 +108,38 @@ func (h *HttpClientAttrsExtractor[REQUEST, RESPONSE, GETTER1, GETTER2]) OnEnd(at
 		Key:   semconv.NetworkProtocolVersionKey,
 		Value: attribute.StringValue(protocolVersion),
 	})
+	
+	// 客户端由于有特有的 hasResponse 属性判断、status_code 哨兵值逻辑以及特定的 error.type 覆盖契约，
+	// 因而此处特意与服务端通用的 Base.OnEnd 进行了逻辑解耦，独立实现。
 	if hasResponse {
 		statusCode := getter.GetHttpResponseStatusCode(request, response, err)
 		attributes = append(attributes, attribute.KeyValue{
 			Key:   semconv.HTTPResponseStatusCodeKey,
 			Value: attribute.IntValue(statusCode),
 		})
+	} else {
+		// Critical #3: 当没有真实响应时，使用哨兵值 0 填充 status_code，保障看板维度兼容
+		attributes = append(attributes, attribute.KeyValue{
+			Key:   semconv.HTTPResponseStatusCodeKey,
+			Value: attribute.IntValue(0),
+		})
 	}
+
 	errorType := getter.GetErrorType(request, response, err)
-	if errorType == "" && err != nil && !hasResponse {
-		errorType = NormalizeHTTPClientErrorType(err)
+	if errorType == "" {
+		if hasResponse {
+			statusCode := getter.GetHttpResponseStatusCode(request, response, err)
+			// Critical #1: 客户端 4xx/5xx (或无效状态码) 在无 err 时设置 status code 为 error.type
+			if statusCode >= 400 || statusCode < 100 {
+				errorType = strconv.Itoa(statusCode)
+			}
+		}
+		// 对齐上游设计，只要有底层的 Go 错误产生，以底层 Go 错误类型优先覆盖
+		if err != nil {
+			errorType = NormalizeHTTPClientErrorType(err)
+		}
 	}
+
 	if errorType != "" {
 		attributes = append(attributes, attribute.KeyValue{
 			Key:   semconv.ErrorTypeKey,

--- a/pkg/inst-api-semconv/instrumenter/http/http_attrs_extractor_test.go
+++ b/pkg/inst-api-semconv/instrumenter/http/http_attrs_extractor_test.go
@@ -16,17 +16,28 @@ package http
 
 import (
 	"context"
+	"errors"
+	stdnet "net"
+	"testing"
+
 	"github.com/alibaba/loongsuite-go/pkg/inst-api-semconv/instrumenter/net"
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.opentelemetry.io/otel/trace"
-	"testing"
 )
 
 type httpServerAttrsGetter struct {
 }
 
 type httpClientAttrsGetter struct {
+}
+
+type customErrorTypeHttpClientAttrsGetter struct {
+	httpClientAttrsGetter
+}
+
+type headerlessResponseHttpClientAttrsGetter struct {
+	httpClientAttrsGetter
 }
 
 type networkAttrsGetter struct {
@@ -97,6 +108,10 @@ func (h httpClientAttrsGetter) GetHttpResponseHeader(request testRequest, respon
 
 func (h httpClientAttrsGetter) GetErrorType(request testRequest, response testResponse, err error) string {
 	return ""
+}
+
+func (h customErrorTypeHttpClientAttrsGetter) GetErrorType(request testRequest, response testResponse, err error) string {
+	return "custom-error-type"
 }
 
 func (h httpClientAttrsGetter) GetNetworkType(request testRequest, response testResponse) string {
@@ -228,21 +243,25 @@ func TestHttpClientExtractorStart(t *testing.T) {
 }
 
 func TestHttpClientExtractorEnd(t *testing.T) {
+	getter := httpClientAttrsGetter{}
 	httpClientExtractor := HttpClientAttrsExtractor[testRequest, testResponse, httpClientAttrsGetter, networkAttrsGetter]{
-		Base:             HttpCommonAttrsExtractor[testRequest, testResponse, httpClientAttrsGetter, networkAttrsGetter]{},
+		Base: HttpCommonAttrsExtractor[testRequest, testResponse, httpClientAttrsGetter, networkAttrsGetter]{
+			HttpGetter: getter,
+			NetGetter:  networkAttrsGetter{},
+		},
 		NetworkExtractor: net.NetworkAttrsExtractor[testRequest, testResponse, networkAttrsGetter]{},
 	}
 	attrs := make([]attribute.KeyValue, 0)
 	parentContext := context.Background()
 	attrs, _ = httpClientExtractor.OnEnd(attrs, parentContext, testRequest{}, testResponse{}, nil)
-	if attrs[0].Key != semconv.HTTPResponseStatusCodeKey || attrs[0].Value.AsInt64() != 200 {
-		t.Fatalf("status code should be 200")
-	}
-	if attrs[1].Key != semconv.NetworkProtocolNameKey || attrs[1].Value.AsString() != "network-protocol-name" {
+	if attrs[0].Key != semconv.NetworkProtocolNameKey || attrs[0].Value.AsString() != "network-protocol-name" {
 		t.Fatalf("wrong network protocol name")
 	}
-	if attrs[2].Key != semconv.NetworkProtocolVersionKey || attrs[2].Value.AsString() != "network-protocol-version" {
+	if attrs[1].Key != semconv.NetworkProtocolVersionKey || attrs[1].Value.AsString() != "network-protocol-version" {
 		t.Fatalf("wrong network protocol version")
+	}
+	if attrs[2].Key != semconv.HTTPResponseStatusCodeKey || attrs[2].Value.AsInt64() != 200 {
+		t.Fatalf("status code should be 200")
 	}
 	if attrs[3].Key != semconv.NetworkTransportKey || attrs[3].Value.AsString() != "network-transport" {
 		t.Fatalf("wrong network transport")
@@ -268,6 +287,79 @@ func TestHttpClientExtractorEnd(t *testing.T) {
 	if attrs[10].Key != semconv.NetworkPeerPortKey || attrs[10].Value.AsInt64() != 8080 {
 		t.Fatalf("wrong network peer port")
 	}
+}
+
+func TestHttpClientExtractorEndTransportError(t *testing.T) {
+	getter := httpClientAttrsGetter{}
+	httpClientExtractor := HttpClientAttrsExtractor[testRequest, testResponse, httpClientAttrsGetter, networkAttrsGetter]{
+		Base: HttpCommonAttrsExtractor[testRequest, testResponse, httpClientAttrsGetter, networkAttrsGetter]{
+			HttpGetter: getter,
+			NetGetter:  networkAttrsGetter{},
+		},
+		NetworkExtractor: net.NetworkAttrsExtractor[testRequest, testResponse, networkAttrsGetter]{},
+	}
+	attrs := make([]attribute.KeyValue, 0)
+	parentContext := context.Background()
+	connectErr := &stdnet.OpError{Op: "dial", Err: errors.New("connection refused")}
+	attrs, _ = httpClientExtractor.OnEnd(attrs, parentContext, testRequest{}, testResponse{}, connectErr)
+	for _, attr := range attrs {
+		if attr.Key == semconv.HTTPResponseStatusCodeKey {
+			t.Fatalf("transport error should not set http.response.status_code")
+		}
+	}
+	var foundErrorType bool
+	for _, attr := range attrs {
+		if attr.Key == semconv.ErrorTypeKey {
+			foundErrorType = true
+			if attr.Value.AsString() != "*net.OpError" {
+				t.Fatalf("error.type should be %q, got %q", "*net.OpError", attr.Value.AsString())
+			}
+		}
+	}
+	if !foundErrorType {
+		t.Fatalf("transport error should set error.type")
+	}
+}
+
+func TestHttpClientExtractorEndUsesGetterErrorType(t *testing.T) {
+	getter := customErrorTypeHttpClientAttrsGetter{}
+	httpClientExtractor := HttpClientAttrsExtractor[testRequest, testResponse, customErrorTypeHttpClientAttrsGetter, networkAttrsGetter]{
+		Base: HttpCommonAttrsExtractor[testRequest, testResponse, customErrorTypeHttpClientAttrsGetter, networkAttrsGetter]{
+			HttpGetter: getter,
+			NetGetter:  networkAttrsGetter{},
+		},
+		NetworkExtractor: net.NetworkAttrsExtractor[testRequest, testResponse, networkAttrsGetter]{},
+	}
+	attrs := make([]attribute.KeyValue, 0)
+	parentContext := context.Background()
+	connectErr := &stdnet.OpError{Op: "dial", Err: errors.New("connection refused")}
+	attrs, _ = httpClientExtractor.OnEnd(attrs, parentContext, testRequest{}, testResponse{}, connectErr)
+	for _, attr := range attrs {
+		if attr.Key == semconv.ErrorTypeKey && attr.Value.AsString() == "custom-error-type" {
+			return
+		}
+	}
+	t.Fatalf("getter error.type should take precedence")
+}
+
+func TestHttpClientExtractorEndWithHeaderlessResponse(t *testing.T) {
+	getter := headerlessResponseHttpClientAttrsGetter{}
+	httpClientExtractor := HttpClientAttrsExtractor[testRequest, testResponse, headerlessResponseHttpClientAttrsGetter, networkAttrsGetter]{
+		Base: HttpCommonAttrsExtractor[testRequest, testResponse, headerlessResponseHttpClientAttrsGetter, networkAttrsGetter]{
+			HttpGetter: getter,
+			NetGetter:  networkAttrsGetter{},
+		},
+		NetworkExtractor: net.NetworkAttrsExtractor[testRequest, testResponse, networkAttrsGetter]{},
+	}
+	attrs := make([]attribute.KeyValue, 0)
+	parentContext := context.Background()
+	attrs, _ = httpClientExtractor.OnEnd(attrs, parentContext, testRequest{}, testResponse{}, nil)
+	for _, attr := range attrs {
+		if attr.Key == semconv.HTTPResponseStatusCodeKey && attr.Value.AsInt64() == 200 {
+			return
+		}
+	}
+	t.Fatalf("successful response should keep http.response.status_code")
 }
 
 func TestHttpServerExtractorStart(t *testing.T) {
@@ -344,6 +436,91 @@ func TestHttpServerExtractorEnd(t *testing.T) {
 	}
 	if attrs[12].Key != semconv.HTTPRouteKey || attrs[12].Value.AsString() != "http-route" {
 		t.Fatalf("httproute should be http-route")
+	}
+}
+
+type httpServerAttrsGetter500 struct {
+	httpServerAttrsGetter
+}
+
+func (h httpServerAttrsGetter500) GetHttpResponseStatusCode(request testRequest, response testResponse, err error) int {
+	return 500
+}
+
+func (h httpServerAttrsGetter500) GetErrorType(request testRequest, response testResponse, err error) string {
+	return ""
+}
+
+type httpServerAttrsGetter500WithCustom struct {
+	httpServerAttrsGetter500
+}
+
+func (h httpServerAttrsGetter500WithCustom) GetErrorType(request testRequest, response testResponse, err error) string {
+	return "custom-error-type"
+}
+
+func TestHttpServerExtractorEnd500(t *testing.T) {
+	httpServerExtractor := HttpServerAttrsExtractor[testRequest, testResponse, httpServerAttrsGetter500, networkAttrsGetter, urlAttrsGetter]{
+		Base: HttpCommonAttrsExtractor[testRequest, testResponse, httpServerAttrsGetter500, networkAttrsGetter]{
+			HttpGetter: httpServerAttrsGetter500{},
+			NetGetter:  networkAttrsGetter{},
+		},
+		NetworkExtractor: net.NetworkAttrsExtractor[testRequest, testResponse, networkAttrsGetter]{},
+		UrlExtractor:     net.UrlAttrsExtractor[testRequest, testResponse, urlAttrsGetter]{},
+	}
+	attrs := make([]attribute.KeyValue, 0)
+	ctx := context.Background()
+	ctx = trace.ContextWithSpan(ctx, &testReadOnlySpan{isRecording: true})
+	attrs, _ = httpServerExtractor.OnEnd(attrs, ctx, testRequest{}, testResponse{}, nil)
+	
+	var foundErrorType bool
+	var errorTypeVal string
+	var errorTypeCount int
+	for _, attr := range attrs {
+		if attr.Key == semconv.ErrorTypeKey {
+			foundErrorType = true
+			errorTypeVal = attr.Value.AsString()
+			errorTypeCount++
+		}
+	}
+	if !foundErrorType {
+		t.Fatalf("should record error.type for 500 response")
+	}
+	if errorTypeVal != "500" {
+		t.Fatalf("error.type should be '500', got %q", errorTypeVal)
+	}
+	if errorTypeCount > 1 {
+		t.Fatalf("should not record duplicate error.type keys")
+	}
+}
+
+func TestHttpServerExtractorEnd500WithCustomErrorType(t *testing.T) {
+	httpServerExtractor := HttpServerAttrsExtractor[testRequest, testResponse, httpServerAttrsGetter500WithCustom, networkAttrsGetter, urlAttrsGetter]{
+		Base: HttpCommonAttrsExtractor[testRequest, testResponse, httpServerAttrsGetter500WithCustom, networkAttrsGetter]{
+			HttpGetter: httpServerAttrsGetter500WithCustom{},
+			NetGetter:  networkAttrsGetter{},
+		},
+		NetworkExtractor: net.NetworkAttrsExtractor[testRequest, testResponse, networkAttrsGetter]{},
+		UrlExtractor:     net.UrlAttrsExtractor[testRequest, testResponse, urlAttrsGetter]{},
+	}
+	attrs := make([]attribute.KeyValue, 0)
+	ctx := context.Background()
+	ctx = trace.ContextWithSpan(ctx, &testReadOnlySpan{isRecording: true})
+	attrs, _ = httpServerExtractor.OnEnd(attrs, ctx, testRequest{}, testResponse{}, nil)
+	
+	var errorTypeCount int
+	var errorTypeVal string
+	for _, attr := range attrs {
+		if attr.Key == semconv.ErrorTypeKey {
+			errorTypeCount++
+			errorTypeVal = attr.Value.AsString()
+		}
+	}
+	if errorTypeCount != 1 {
+		t.Fatalf("expected exactly 1 error.type attribute, got %d", errorTypeCount)
+	}
+	if errorTypeVal != "custom-error-type" {
+		t.Fatalf("expected error.type to be 'custom-error-type', got %q", errorTypeVal)
 	}
 }
 

--- a/pkg/inst-api-semconv/instrumenter/http/http_attrs_extractor_test.go
+++ b/pkg/inst-api-semconv/instrumenter/http/http_attrs_extractor_test.go
@@ -17,6 +17,7 @@ package http
 import (
 	"context"
 	"errors"
+	"fmt"
 	stdnet "net"
 	"testing"
 
@@ -302,10 +303,19 @@ func TestHttpClientExtractorEndTransportError(t *testing.T) {
 	parentContext := context.Background()
 	connectErr := &stdnet.OpError{Op: "dial", Err: errors.New("connection refused")}
 	attrs, _ = httpClientExtractor.OnEnd(attrs, parentContext, testRequest{}, testResponse{}, connectErr)
+	var foundStatusCode bool
+	var statusCodeVal int64
 	for _, attr := range attrs {
 		if attr.Key == semconv.HTTPResponseStatusCodeKey {
-			t.Fatalf("transport error should not set http.response.status_code")
+			foundStatusCode = true
+			statusCodeVal = attr.Value.AsInt64()
 		}
+	}
+	if !foundStatusCode {
+		t.Fatalf("transport error should set http.response.status_code to sentinel 0")
+	}
+	if statusCodeVal != 0 {
+		t.Fatalf("expected status_code to be 0 for transport error, got %d", statusCodeVal)
 	}
 	var foundErrorType bool
 	for _, attr := range attrs {
@@ -618,5 +628,187 @@ func TestNonRecordingSpan(t *testing.T) {
 	}
 	if attrs[11].Key != semconv.NetworkPeerPortKey || attrs[11].Value.AsInt64() != 8080 {
 		t.Fatalf("wrong network peer port")
+	}
+}
+
+type resolverHttpClientAttrsGetter struct {
+	httpClientAttrsGetter
+	hasResponse bool
+}
+
+func (h resolverHttpClientAttrsGetter) HasHttpResponse(request testRequest, response testResponse, err error) bool {
+	return h.hasResponse
+}
+
+func TestHttpClientExtractorEndResolverTrueWithError(t *testing.T) {
+	getter := resolverHttpClientAttrsGetter{hasResponse: true}
+	httpClientExtractor := HttpClientAttrsExtractor[testRequest, testResponse, resolverHttpClientAttrsGetter, networkAttrsGetter]{
+		Base: HttpCommonAttrsExtractor[testRequest, testResponse, resolverHttpClientAttrsGetter, networkAttrsGetter]{
+			HttpGetter: getter,
+			NetGetter:  networkAttrsGetter{},
+		},
+		NetworkExtractor: net.NetworkAttrsExtractor[testRequest, testResponse, networkAttrsGetter]{},
+	}
+	attrs := make([]attribute.KeyValue, 0)
+	parentContext := context.Background()
+	connectErr := &stdnet.OpError{Op: "dial", Err: errors.New("connection refused")}
+	attrs, _ = httpClientExtractor.OnEnd(attrs, parentContext, testRequest{}, testResponse{}, connectErr)
+
+	var statusCodeVal int64
+	var foundStatusCode bool
+	var errorTypeVal string
+	var foundErrorType bool
+
+	for _, attr := range attrs {
+		if attr.Key == semconv.HTTPResponseStatusCodeKey {
+			foundStatusCode = true
+			statusCodeVal = attr.Value.AsInt64()
+		}
+		if attr.Key == semconv.ErrorTypeKey {
+			foundErrorType = true
+			errorTypeVal = attr.Value.AsString()
+		}
+	}
+
+	if !foundStatusCode {
+		t.Fatalf("expected http.response.status_code when hasResponse is true")
+	}
+	if statusCodeVal != 200 {
+		t.Fatalf("expected status_code to be 200, got %d", statusCodeVal)
+	}
+	if !foundErrorType {
+		t.Fatalf("expected error.type when err != nil")
+	}
+	if errorTypeVal != "*net.OpError" {
+		t.Fatalf("expected error.type to be '*net.OpError', got %q", errorTypeVal)
+	}
+}
+
+type resolverStatusCodeHttpClientAttrsGetter struct {
+	httpClientAttrsGetter
+	hasResponse bool
+	code        int
+}
+
+func (h resolverStatusCodeHttpClientAttrsGetter) HasHttpResponse(request testRequest, response testResponse, err error) bool {
+	return h.hasResponse
+}
+
+func (h resolverStatusCodeHttpClientAttrsGetter) GetHttpResponseStatusCode(request testRequest, response testResponse, err error) int {
+	return h.code
+}
+
+func TestHttpClientExtractorEndResolverTrueWithErrorAnd4xxStatusPrefersGoErrorType(t *testing.T) {
+	getter := resolverStatusCodeHttpClientAttrsGetter{hasResponse: true, code: 404}
+	httpClientExtractor := HttpClientAttrsExtractor[testRequest, testResponse, resolverStatusCodeHttpClientAttrsGetter, networkAttrsGetter]{
+		Base: HttpCommonAttrsExtractor[testRequest, testResponse, resolverStatusCodeHttpClientAttrsGetter, networkAttrsGetter]{
+			HttpGetter: getter,
+			NetGetter:  networkAttrsGetter{},
+		},
+		NetworkExtractor: net.NetworkAttrsExtractor[testRequest, testResponse, networkAttrsGetter]{},
+	}
+	attrs := make([]attribute.KeyValue, 0)
+	parentContext := context.Background()
+	wrappedErr := fmt.Errorf("middleware failed: %w", &stdnet.OpError{Op: "dial", Err: errors.New("connection refused")})
+	attrs, _ = httpClientExtractor.OnEnd(attrs, parentContext, testRequest{}, testResponse{}, wrappedErr)
+
+	var statusCodeVal int64
+	var foundStatusCode bool
+	var errorTypeVal string
+	var foundErrorType bool
+
+	for _, attr := range attrs {
+		if attr.Key == semconv.HTTPResponseStatusCodeKey {
+			foundStatusCode = true
+			statusCodeVal = attr.Value.AsInt64()
+		}
+		if attr.Key == semconv.ErrorTypeKey {
+			foundErrorType = true
+			errorTypeVal = attr.Value.AsString()
+		}
+	}
+
+	if !foundStatusCode {
+		t.Fatalf("expected http.response.status_code when hasResponse is true")
+	}
+	if statusCodeVal != 404 {
+		t.Fatalf("expected status_code to be 404, got %d", statusCodeVal)
+	}
+	if !foundErrorType {
+		t.Fatalf("expected error.type when err != nil")
+	}
+	if errorTypeVal != "*net.OpError" {
+		t.Fatalf("expected error.type to be '*net.OpError', got %q", errorTypeVal)
+	}
+}
+
+func TestHttpClientExtractorEndResolverFalse(t *testing.T) {
+	getter := resolverHttpClientAttrsGetter{hasResponse: false}
+	httpClientExtractor := HttpClientAttrsExtractor[testRequest, testResponse, resolverHttpClientAttrsGetter, networkAttrsGetter]{
+		Base: HttpCommonAttrsExtractor[testRequest, testResponse, resolverHttpClientAttrsGetter, networkAttrsGetter]{
+			HttpGetter: getter,
+			NetGetter:  networkAttrsGetter{},
+		},
+		NetworkExtractor: net.NetworkAttrsExtractor[testRequest, testResponse, networkAttrsGetter]{},
+	}
+	attrs := make([]attribute.KeyValue, 0)
+	parentContext := context.Background()
+	attrs, _ = httpClientExtractor.OnEnd(attrs, parentContext, testRequest{}, testResponse{}, nil)
+
+	var statusCodeVal int64
+	var foundStatusCode bool
+
+	for _, attr := range attrs {
+		if attr.Key == semconv.HTTPResponseStatusCodeKey {
+			foundStatusCode = true
+			statusCodeVal = attr.Value.AsInt64()
+		}
+	}
+
+	if !foundStatusCode {
+		t.Fatalf("expected http.response.status_code sentinel even when hasResponse is false")
+	}
+	if statusCodeVal != 0 {
+		t.Fatalf("expected status_code to be sentinel 0, got %d", statusCodeVal)
+	}
+}
+
+type errorStatusCodeResolverHttpClientAttrsGetter struct {
+	httpClientAttrsGetter
+	code int
+}
+
+func (h errorStatusCodeResolverHttpClientAttrsGetter) GetHttpResponseStatusCode(request testRequest, response testResponse, err error) int {
+	return h.code
+}
+
+func TestHttpClientExtractorEnd400ErrorTypeFallback(t *testing.T) {
+	getter := errorStatusCodeResolverHttpClientAttrsGetter{code: 404}
+	httpClientExtractor := HttpClientAttrsExtractor[testRequest, testResponse, errorStatusCodeResolverHttpClientAttrsGetter, networkAttrsGetter]{
+		Base: HttpCommonAttrsExtractor[testRequest, testResponse, errorStatusCodeResolverHttpClientAttrsGetter, networkAttrsGetter]{
+			HttpGetter: getter,
+			NetGetter:  networkAttrsGetter{},
+		},
+		NetworkExtractor: net.NetworkAttrsExtractor[testRequest, testResponse, networkAttrsGetter]{},
+	}
+	attrs := make([]attribute.KeyValue, 0)
+	parentContext := context.Background()
+	attrs, _ = httpClientExtractor.OnEnd(attrs, parentContext, testRequest{}, testResponse{}, nil)
+
+	var errorTypeVal string
+	var foundErrorType bool
+
+	for _, attr := range attrs {
+		if attr.Key == semconv.ErrorTypeKey {
+			foundErrorType = true
+			errorTypeVal = attr.Value.AsString()
+		}
+	}
+
+	if !foundErrorType {
+		t.Fatalf("expected error.type fallback for 404 status code when err is nil")
+	}
+	if errorTypeVal != "404" {
+		t.Fatalf("expected error.type fallback to be '404', got %q", errorTypeVal)
 	}
 }

--- a/pkg/inst-api-semconv/instrumenter/http/http_client_error.go
+++ b/pkg/inst-api-semconv/instrumenter/http/http_client_error.go
@@ -15,9 +15,37 @@
 package http
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 )
+
+func unwrapFmtWrapped(err error) error {
+	for err != nil {
+		t := reflect.TypeOf(err)
+		if t == nil {
+			break
+		}
+		name := t.String()
+		if name == "*fmt.wrapError" {
+			err = errors.Unwrap(err)
+		} else if name == "*errors.joinError" {
+			if je, ok := err.(interface{ Unwrap() []error }); ok {
+				errs := je.Unwrap()
+				if len(errs) > 0 {
+					err = errs[0]
+				} else {
+					break
+				}
+			} else {
+				break
+			}
+		} else {
+			break
+		}
+	}
+	return err
+}
 
 // NormalizeHTTPClientErrorType follows the upstream HTTPClientErrorType behavior
 // and uses the concrete Go error type as the error.type value.
@@ -25,6 +53,27 @@ func NormalizeHTTPClientErrorType(err error) string {
 	if err == nil {
 		return ""
 	}
+
+	// 1. 先进行 ErrorType() 接口判定，允许自定义错误控制
+	if et, ok := err.(interface{ ErrorType() string }); ok {
+		if s := et.ErrorType(); s != "" {
+			return s
+		}
+	}
+
+	// 2. 解包 fmt.Errorf("%w") 和 errors.Join 产生的标准库包装类，获取底层具体错误
+	err = unwrapFmtWrapped(err)
+	if err == nil {
+		return ""
+	}
+
+	// 3. 对解包后的具体错误，如果实现了 ErrorType() 同样优先调用
+	if et, ok := err.(interface{ ErrorType() string }); ok {
+		if s := et.ErrorType(); s != "" {
+			return s
+		}
+	}
+
 	t := reflect.TypeOf(err)
 	if t == nil {
 		return ""
@@ -32,9 +81,5 @@ func NormalizeHTTPClientErrorType(err error) string {
 	if t.PkgPath() == "" && t.Name() == "" {
 		return t.String()
 	}
-	value := fmt.Sprintf("%s.%s", t.PkgPath(), t.Name())
-	if value == "." {
-		return "_OTHER"
-	}
-	return value
+	return fmt.Sprintf("%s.%s", t.PkgPath(), t.Name())
 }

--- a/pkg/inst-api-semconv/instrumenter/http/http_client_error.go
+++ b/pkg/inst-api-semconv/instrumenter/http/http_client_error.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2024 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// NormalizeHTTPClientErrorType follows the upstream HTTPClientErrorType behavior
+// and uses the concrete Go error type as the error.type value.
+func NormalizeHTTPClientErrorType(err error) string {
+	if err == nil {
+		return ""
+	}
+	t := reflect.TypeOf(err)
+	if t == nil {
+		return ""
+	}
+	if t.PkgPath() == "" && t.Name() == "" {
+		return t.String()
+	}
+	value := fmt.Sprintf("%s.%s", t.PkgPath(), t.Name())
+	if value == "." {
+		return "_OTHER"
+	}
+	return value
+}

--- a/pkg/inst-api-semconv/instrumenter/http/http_client_error_test.go
+++ b/pkg/inst-api-semconv/instrumenter/http/http_client_error_test.go
@@ -16,6 +16,7 @@ package http
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"testing"
 )
@@ -49,5 +50,41 @@ func TestNormalizeHTTPClientErrorTypeOther(t *testing.T) {
 func TestNormalizeHTTPClientErrorTypeNil(t *testing.T) {
 	if got := NormalizeHTTPClientErrorType(nil); got != "" {
 		t.Fatalf("expected empty string, got %q", got)
+	}
+}
+
+type customErrorType struct {
+	msg string
+}
+
+func (c customErrorType) Error() string {
+	return c.msg
+}
+
+func (c customErrorType) ErrorType() string {
+	return "my-custom-error-type"
+}
+
+func TestNormalizeHTTPClientErrorTypeCustom(t *testing.T) {
+	err := customErrorType{msg: "error"}
+	if got := NormalizeHTTPClientErrorType(err); got != "my-custom-error-type" {
+		t.Fatalf("expected %q, got %q", "my-custom-error-type", got)
+	}
+}
+
+func TestNormalizeHTTPClientErrorTypeWrapped(t *testing.T) {
+	baseErr := &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+	wrappedErr := fmt.Errorf("middleware failed: %w", baseErr)
+	if got := NormalizeHTTPClientErrorType(wrappedErr); got != "*net.OpError" {
+		t.Fatalf("expected %q, got %q", "*net.OpError", got)
+	}
+}
+
+func TestNormalizeHTTPClientErrorTypeDoubleWrapped(t *testing.T) {
+	baseErr := customErrorType{msg: "db timeout"}
+	wrappedErr1 := fmt.Errorf("db failure: %w", baseErr)
+	wrappedErr2 := fmt.Errorf("app execution failed: %w", wrappedErr1)
+	if got := NormalizeHTTPClientErrorType(wrappedErr2); got != "my-custom-error-type" {
+		t.Fatalf("expected %q, got %q", "my-custom-error-type", got)
 	}
 }

--- a/pkg/inst-api-semconv/instrumenter/http/http_client_error_test.go
+++ b/pkg/inst-api-semconv/instrumenter/http/http_client_error_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2024 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http
+
+import (
+	"errors"
+	"net"
+	"testing"
+)
+
+func TestNormalizeHTTPClientErrorTypeConnect(t *testing.T) {
+	err := &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+	if got := NormalizeHTTPClientErrorType(err); got != "*net.OpError" {
+		t.Fatalf("expected %q, got %q", "*net.OpError", got)
+	}
+}
+
+func TestNormalizeHTTPClientErrorTypeDNS(t *testing.T) {
+	err := &net.DNSError{Err: "no such host", Name: "example.invalid"}
+	if got := NormalizeHTTPClientErrorType(err); got != "*net.DNSError" {
+		t.Fatalf("expected %q, got %q", "*net.DNSError", got)
+	}
+}
+
+func TestNormalizeHTTPClientErrorTypeTimeout(t *testing.T) {
+	if got := NormalizeHTTPClientErrorType(errors.New("timeout")); got != "*errors.errorString" {
+		t.Fatalf("expected %q, got %q", "*errors.errorString", got)
+	}
+}
+
+func TestNormalizeHTTPClientErrorTypeOther(t *testing.T) {
+	if got := NormalizeHTTPClientErrorType(errors.New("boom")); got != "*errors.errorString" {
+		t.Fatalf("expected %q, got %q", "*errors.errorString", got)
+	}
+}
+
+func TestNormalizeHTTPClientErrorTypeNil(t *testing.T) {
+	if got := NormalizeHTTPClientErrorType(nil); got != "" {
+		t.Fatalf("expected empty string, got %q", got)
+	}
+}

--- a/pkg/inst-api-semconv/instrumenter/http/http_status_code_extractor.go
+++ b/pkg/inst-api-semconv/instrumenter/http/http_status_code_extractor.go
@@ -24,6 +24,9 @@ type HttpClientSpanStatusExtractor[REQUEST any, RESPONSE any] struct {
 }
 
 func (h HttpClientSpanStatusExtractor[REQUEST, RESPONSE]) Extract(span trace.Span, request REQUEST, response RESPONSE, err error) {
+	// Minor #10: 客户端 Extract 在 err != nil 时提前返回，不调用 span.RecordError(err)。
+	// 这是因为 InternalInstrumenter.doEnd 会优先在 Extractor 之前调用 RecordError 并将状态设为 Error，
+	// 此处直接 early return 避免重复记录，属于有意设计的隐式依赖关系。
 	if err != nil {
 		return
 	}

--- a/pkg/inst-api-semconv/instrumenter/http/http_status_code_extractor.go
+++ b/pkg/inst-api-semconv/instrumenter/http/http_status_code_extractor.go
@@ -15,29 +15,21 @@
 package http
 
 import (
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.opentelemetry.io/otel/trace"
-	"strconv"
 )
-
-const invalidHttpStatusCode = "INVALID_HTTP_STATUS_CODE"
 
 type HttpClientSpanStatusExtractor[REQUEST any, RESPONSE any] struct {
 	Getter HttpCommonAttrsGetter[REQUEST, RESPONSE]
 }
 
 func (h HttpClientSpanStatusExtractor[REQUEST, RESPONSE]) Extract(span trace.Span, request REQUEST, response RESPONSE, err error) {
+	if err != nil {
+		return
+	}
 	statusCode := h.Getter.GetHttpResponseStatusCode(request, response, err)
 	if statusCode >= 400 || statusCode < 100 {
-		if err != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
-		} else {
-			span.SetStatus(codes.Error, invalidHttpStatusCode)
-		}
-		span.SetAttributes(attribute.KeyValue{Key: semconv.ErrorTypeKey, Value: attribute.StringValue(strconv.Itoa(statusCode))})
+		span.SetStatus(codes.Error, "")
 	} else if statusCode >= 200 && statusCode < 300 {
 		span.SetStatus(codes.Ok, "success")
 	}
@@ -54,9 +46,8 @@ func (h HttpServerSpanStatusExtractor[REQUEST, RESPONSE]) Extract(span trace.Spa
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
 		} else {
-			span.SetStatus(codes.Error, invalidHttpStatusCode)
+			span.SetStatus(codes.Error, "")
 		}
-		span.SetAttributes(attribute.KeyValue{Key: semconv.ErrorTypeKey, Value: attribute.StringValue(strconv.Itoa(statusCode))})
 	} else if statusCode >= 200 && statusCode < 300 {
 		span.SetStatus(codes.Ok, "success")
 	}

--- a/pkg/inst-api-semconv/instrumenter/http/http_status_code_extractor_test.go
+++ b/pkg/inst-api-semconv/instrumenter/http/http_status_code_extractor_test.go
@@ -15,6 +15,7 @@
 package http
 
 import (
+	"errors"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -103,8 +104,8 @@ func TestHttpClientSpanStatusExtractor400(t *testing.T) {
 	if *span.status != codes.Error {
 		panic("span status should be error!")
 	}
-	if span.Kvs == nil {
-		panic("kv should not be nil")
+	if span.Kvs != nil {
+		panic("kv should be nil for 400 status code")
 	}
 }
 
@@ -119,6 +120,20 @@ func TestHttpClientSpanStatusExtractor200(t *testing.T) {
 	c.Extract(span, nil, nil, nil)
 	if *span.status != codes.Ok {
 		panic("span status should be ok!")
+	}
+}
+
+func TestHttpClientSpanStatusExtractorTransportError(t *testing.T) {
+	c := HttpClientSpanStatusExtractor[any, any]{
+		Getter: customizedNetHttpAttrsGetter{
+			code: 200,
+		},
+	}
+	u := codes.Error
+	span := &testSpan{status: &u}
+	c.Extract(span, nil, nil, errors.New("connection refused"))
+	if *span.status != codes.Error {
+		panic("span status should remain error when err != nil")
 	}
 }
 func TestHttpClientSpanStatusExtractor201(t *testing.T) {
@@ -146,8 +161,8 @@ func TestHttpServerSpanStatusExtractor500(t *testing.T) {
 	if *span.status != codes.Error {
 		panic("span status should be error!")
 	}
-	if span.Kvs == nil {
-		panic("kv should not be nil")
+	if span.Kvs != nil {
+		panic("kv should be nil for 500 status code")
 	}
 }
 

--- a/pkg/rules/fasthttp/fasthttp_otel_instrumenter.go
+++ b/pkg/rules/fasthttp/fasthttp_otel_instrumenter.go
@@ -58,7 +58,7 @@ func (n fastHttpClientAttrsGetter) GetHttpResponseStatusCode(request fastHttpReq
 }
 
 func (n fastHttpClientAttrsGetter) HasHttpResponse(request fastHttpRequest, response fastHttpResponse, err error) bool {
-	return err == nil
+	return response.statusCode >= 100
 }
 
 func (n fastHttpClientAttrsGetter) GetHttpResponseHeader(request fastHttpRequest, response fastHttpResponse, name string) []string {

--- a/pkg/rules/fasthttp/fasthttp_otel_instrumenter.go
+++ b/pkg/rules/fasthttp/fasthttp_otel_instrumenter.go
@@ -56,6 +56,11 @@ func (n fastHttpClientAttrsGetter) GetHttpRequestHeader(request fastHttpRequest,
 func (n fastHttpClientAttrsGetter) GetHttpResponseStatusCode(request fastHttpRequest, response fastHttpResponse, err error) int {
 	return response.statusCode
 }
+
+func (n fastHttpClientAttrsGetter) HasHttpResponse(request fastHttpRequest, response fastHttpResponse, err error) bool {
+	return err == nil
+}
+
 func (n fastHttpClientAttrsGetter) GetHttpResponseHeader(request fastHttpRequest, response fastHttpResponse, name string) []string {
 	all := make([]string, 0)
 	for _, header := range response.header.PeekAll(name) {

--- a/pkg/rules/gomicro/gomicro_service_otel_instrumenter.go
+++ b/pkg/rules/gomicro/gomicro_service_otel_instrumenter.go
@@ -50,6 +50,10 @@ func (n goMicroHttpClientAttrsGetter) GetHttpRequestHeader(request goMicroReques
 	return all
 }
 func (n goMicroHttpClientAttrsGetter) GetHttpResponseStatusCode(request goMicroRequest, response goMicroResponse, err error) int {
+	// Minor #7: 恢复原有的 GetHttpResponseStatusCode 逻辑以满足接口契约
+	if response.err != nil {
+		return 500
+	}
 	return 200
 }
 

--- a/pkg/rules/gomicro/gomicro_service_otel_instrumenter.go
+++ b/pkg/rules/gomicro/gomicro_service_otel_instrumenter.go
@@ -50,11 +50,13 @@ func (n goMicroHttpClientAttrsGetter) GetHttpRequestHeader(request goMicroReques
 	return all
 }
 func (n goMicroHttpClientAttrsGetter) GetHttpResponseStatusCode(request goMicroRequest, response goMicroResponse, err error) int {
-	if response.err != nil {
-		return 500
-	}
 	return 200
 }
+
+func (n goMicroHttpClientAttrsGetter) HasHttpResponse(request goMicroRequest, response goMicroResponse, err error) bool {
+	return err == nil
+}
+
 func (n goMicroHttpClientAttrsGetter) GetHttpResponseHeader(request goMicroRequest, response goMicroResponse, name string) []string {
 	all := make([]string, 0)
 	md, ok := metadata.FromContext(response.ctx)

--- a/pkg/rules/hertz/client/hertz_http_otel_instrumenter.go
+++ b/pkg/rules/hertz/client/hertz_http_otel_instrumenter.go
@@ -56,7 +56,7 @@ func (h hertzHttpClientAttrsGetter) GetHttpResponseStatusCode(request *protocol.
 }
 
 func (h hertzHttpClientAttrsGetter) HasHttpResponse(request *protocol.Request, response *protocol.Response, err error) bool {
-	return err == nil
+	return response != nil && response.StatusCode() >= 100
 }
 
 func (h hertzHttpClientAttrsGetter) GetHttpResponseHeader(request *protocol.Request, response *protocol.Response, name string) []string {

--- a/pkg/rules/hertz/client/hertz_http_otel_instrumenter.go
+++ b/pkg/rules/hertz/client/hertz_http_otel_instrumenter.go
@@ -55,6 +55,10 @@ func (h hertzHttpClientAttrsGetter) GetHttpResponseStatusCode(request *protocol.
 	return response.StatusCode()
 }
 
+func (h hertzHttpClientAttrsGetter) HasHttpResponse(request *protocol.Request, response *protocol.Response, err error) bool {
+	return err == nil
+}
+
 func (h hertzHttpClientAttrsGetter) GetHttpResponseHeader(request *protocol.Request, response *protocol.Response, name string) []string {
 	keys := make([]string, 0)
 	response.Header.VisitAll(func(key, value []byte) {

--- a/pkg/rules/http/client_setup.go
+++ b/pkg/rules/http/client_setup.go
@@ -61,8 +61,9 @@ func clientOnEnter(call api.CallContext, t *http.Transport, req *http.Request) {
 	ctx := netHttpClientInstrumenter.Start(req.Context(), netHttpRequest)
 	req = req.WithContext(ctx)
 	call.SetParam(1, req)
-	data := make(map[string]interface{}, 1)
+	data := make(map[string]interface{}, 2)
 	data["ctx"] = ctx
+	data["request"] = netHttpRequest
 	call.SetData(data)
 	return
 }
@@ -86,12 +87,12 @@ func clientOnExit(call api.CallContext, res *http.Response, err error) {
 			host:    res.Request.Host,
 			isTls:   res.Request.TLS != nil,
 		}, &netHttpResponse{
-			statusCode: res.StatusCode,
-			header:     res.Header,
+			statusCode:  res.StatusCode,
+			header:      res.Header,
+			hasResponse: true,
 		}, err)
 	} else {
-		netHttpClientInstrumenter.End(ctx, &netHttpRequest{}, &netHttpResponse{
-			statusCode: 500,
-		}, err)
+		request := data["request"].(*netHttpRequest)
+		netHttpClientInstrumenter.End(ctx, request, &netHttpResponse{}, err)
 	}
 }

--- a/pkg/rules/http/client_setup.go
+++ b/pkg/rules/http/client_setup.go
@@ -92,7 +92,11 @@ func clientOnExit(call api.CallContext, res *http.Response, err error) {
 			hasResponse: true,
 		}, err)
 	} else {
-		request := data["request"].(*netHttpRequest)
+		// Major #5: 防御性类型断言以避免在 nil 或类型不匹配时 panic；并在失败时降级收尾以保证闭合 span
+		request, ok := data["request"].(*netHttpRequest)
+		if !ok {
+			request = &netHttpRequest{}
+		}
 		netHttpClientInstrumenter.End(ctx, request, &netHttpResponse{}, err)
 	}
 }

--- a/pkg/rules/http/net_http_data_type.go
+++ b/pkg/rules/http/net_http_data_type.go
@@ -30,8 +30,9 @@ type netHttpRequest struct {
 }
 
 type netHttpResponse struct {
-	statusCode int
-	header     http.Header
+	statusCode  int
+	header      http.Header
+	hasResponse bool
 }
 
 func getProtocolVersion(majorVersion, minorVersion int) string {

--- a/pkg/rules/http/net_http_otel_instrumenter.go
+++ b/pkg/rules/http/net_http_otel_instrumenter.go
@@ -56,6 +56,10 @@ func (n netHttpClientAttrsGetter) GetHttpResponseStatusCode(request *netHttpRequ
 	return response.statusCode
 }
 
+func (n netHttpClientAttrsGetter) HasHttpResponse(request *netHttpRequest, response *netHttpResponse, err error) bool {
+	return response != nil && response.hasResponse
+}
+
 func (n netHttpClientAttrsGetter) GetHttpResponseHeader(request *netHttpRequest, response *netHttpResponse, name string) []string {
 	return response.header.Values(name)
 }


### PR DESCRIPTION
## Summary

This PR refines HTTP instrumentation semantics by clearly separating client transport failures from real HTTP responses, and by aligning `error.type` handling across client/server paths with OTel expectations.

## What changed

### 1) Shared HTTP semconv logic

- Added/updated client error normalization helper:
  - `pkg/inst-api-semconv/instrumenter/http/http_client_error.go`
- Updated client attribute extraction:
  - `pkg/inst-api-semconv/instrumenter/http/http_attrs_extractor.go`
- Updated client status extraction comment/behavior notes:
  - `pkg/inst-api-semconv/instrumenter/http/http_status_code_extractor.go`
- Added/updated related tests:
  - `pkg/inst-api-semconv/instrumenter/http/http_client_error_test.go`
  - `pkg/inst-api-semconv/instrumenter/http/http_attrs_extractor_test.go`
  - `pkg/inst-api-semconv/instrumenter/http/http_status_code_extractor_test.go`

### 2) Rule-layer adjustments

- net/http client exit path defensive handling:
  - `pkg/rules/http/client_setup.go`
- go-micro client status code contract compatibility:
  - `pkg/rules/gomicro/gomicro_service_otel_instrumenter.go`

## Behavior changes (compatibility notes)

### Client transport failures now emit `http.response.status_code=0`

Previously, transport failures (no real HTTP response) could be grouped under synthetic `500` behavior.

After this change, when no real HTTP response is received:

- `http.response.status_code = 0` (sentinel)
- `error.type = <underlying Go error type>`

This keeps `http.response.status_code` present as a metric dimension while distinguishing transport failures from real HTTP 5xx responses.

**Compatibility impact:** dashboards/alerts grouped by `http.response.status_code` should treat `0` as transport-failure/no-response cases.

### Server 4xx responses no longer emit `error.type`

Server-side `error.type` is now emitted only for:

- `5xx` responses
- invalid status codes (`<100`)

This aligns with OTel semantics (4xx is not treated as server error).

**Compatibility impact:** users relying on server-side 4xx `error.type` (for example `"404"`) should migrate alerting/queries to `http.response.status_code`.

## Resolver-path and precedence guarantees

The client resolver path is now covered by tests, including the key scenario:

- `hasResponse == true && err != nil && statusCode == 4xx`

Expected behavior:

- preserve real `http.response.status_code`
- prefer underlying Go error type for `error.type` when `err != nil`

## Validation

Executed locally:

- `go test ./pkg/inst-api-semconv/instrumenter/http/...`

## Related issue

Fixes #713