### PR TITLE
test(util-genai): add integration tests and CI pipeline

### DIFF
--- a/.github/workflows/util-genai.yml
+++ b/.github/workflows/util-genai.yml
@@ -1,0 +1,52 @@
+# This workflow builds and tests the util-genai module and its integration tests.
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: UtilGenAI
+
+on:
+  push:
+    branches: [ "main", "dev" ]
+    paths:
+      - 'util-genai/**'
+      - '.github/workflows/util-genai.yml'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'util-genai/**'
+      - '.github/workflows/util-genai.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # go.sum and vendor/ are git-ignored repo-wide, so resolve modules from the
+    # network at build time instead of expecting a checked-in go.sum/vendor.
+    env:
+      GOFLAGS: -mod=mod
+    strategy:
+      matrix:
+        go_version:
+          - 1.24
+          - 1.25
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ matrix.go_version }}
+
+    - name: Build (library)
+      working-directory: util-genai
+      run: go build ./...
+
+    - name: Vet (library)
+      working-directory: util-genai
+      run: go vet ./...
+
+    - name: Unit tests (library)
+      working-directory: util-genai
+      run: go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
+
+    - name: Integration tests
+      working-directory: util-genai/integration
+      run: go test -race -v ./...

--- a/util-genai/integration/go.mod
+++ b/util-genai/integration/go.mod
@@ -1,0 +1,25 @@
+module github.com/alibaba/loongsuite-go/util-genai/integration
+
+go 1.24.0
+
+replace github.com/alibaba/loongsuite-go/util-genai => ../
+
+require (
+	github.com/alibaba/loongsuite-go/util-genai v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel v1.40.0
+	go.opentelemetry.io/otel/sdk v1.40.0
+	go.opentelemetry.io/otel/sdk/log v0.16.0
+	go.opentelemetry.io/otel/sdk/metric v1.40.0
+)
+
+require (
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/otel/log v0.16.0 // indirect
+	go.opentelemetry.io/otel/metric v1.40.0 // indirect
+	go.opentelemetry.io/otel/trace v1.40.0 // indirect
+	golang.org/x/sys v0.40.0 // indirect
+)

--- a/util-genai/integration/integration_test.go
+++ b/util-genai/integration/integration_test.go
@@ -1,0 +1,307 @@
+// Copyright (c) 2024 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package integration contains end-to-end tests for the util-genai telemetry
+// handler. Unlike the unit tests that live alongside the library, these tests
+// wire the handler to in-memory OpenTelemetry SDK exporters and assert on the
+// spans, metrics, and log events that are actually produced across a full
+// invocation lifecycle.
+//
+// The tests live in a separate module so that the util-genai library itself can
+// keep an API-only dependency surface (no OTel SDK), while the tests are free to
+// pull in the SDK exporters they need.
+package integration
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	utilgenai "github.com/alibaba/loongsuite-go/util-genai"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// memLogExporter is a minimal in-memory implementation of sdklog.Exporter that
+// records every log record it receives so tests can assert on emitted events.
+type memLogExporter struct {
+	mu      sync.Mutex
+	records []sdklog.Record
+}
+
+func (e *memLogExporter) Export(_ context.Context, records []sdklog.Record) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.records = append(e.records, records...)
+	return nil
+}
+
+func (e *memLogExporter) Shutdown(context.Context) error { return nil }
+
+func (e *memLogExporter) ForceFlush(context.Context) error { return nil }
+
+func (e *memLogExporter) eventNames() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	names := make([]string, 0, len(e.records))
+	for i := range e.records {
+		names = append(names, e.records[i].EventName())
+	}
+	return names
+}
+
+// harness bundles the in-memory providers and the handler under test.
+type harness struct {
+	handler   *utilgenai.TelemetryHandler
+	spans     *tracetest.SpanRecorder
+	reader    *sdkmetric.ManualReader
+	logExport *memLogExporter
+}
+
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+
+	spans := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spans))
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	logExport := &memLogExporter{}
+	lp := sdklog.NewLoggerProvider(
+		sdklog.WithProcessor(sdklog.NewSimpleProcessor(logExport)),
+	)
+
+	handler := utilgenai.NewTelemetryHandler(
+		utilgenai.WithTracerProvider(tp),
+		utilgenai.WithMeterProvider(mp),
+		utilgenai.WithLoggerProvider(lp),
+	)
+
+	return &harness{handler: handler, spans: spans, reader: reader, logExport: logExport}
+}
+
+// collectMetric returns the metric with the given name from the manual reader,
+// failing the test if it is absent.
+func (h *harness) collectMetric(t *testing.T, name string) metricdata.Metrics {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := h.reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect metrics: %v", err)
+	}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				return m
+			}
+		}
+	}
+	t.Fatalf("metric %q not found in collected metrics", name)
+	return metricdata.Metrics{}
+}
+
+func attrMap(kvs []attribute.KeyValue) map[string]attribute.Value {
+	m := make(map[string]attribute.Value, len(kvs))
+	for _, kv := range kvs {
+		m[string(kv.Key)] = kv.Value
+	}
+	return m
+}
+
+// TestLLMLifecycleSuccess drives a full successful chat completion through the
+// handler and asserts the resulting span, metrics, and event.
+func TestLLMLifecycleSuccess(t *testing.T) {
+	// Enable experimental semconv + event emission so the inference event fires.
+	t.Setenv(utilgenai.EnvSemconvStabilityOptIn, "gen_ai_latest_experimental")
+	t.Setenv(utilgenai.EnvEmitEvent, "true")
+
+	h := newHarness(t)
+	ctx := context.Background()
+
+	inv := utilgenai.NewLLMInvocation("gpt-4")
+	inv.Provider = "openai"
+	inv.InputMessages = []utilgenai.InputMessage{
+		{Role: "user", Parts: []utilgenai.MessagePart{utilgenai.Text{Content: "Hello!"}}},
+	}
+
+	ctx = h.handler.StartLLM(ctx, inv)
+	_ = ctx
+
+	inv.OutputMessages = []utilgenai.OutputMessage{
+		{
+			Role:         "assistant",
+			Parts:        []utilgenai.MessagePart{utilgenai.Text{Content: "Hi there!"}},
+			FinishReason: utilgenai.FinishReasonStop,
+		},
+	}
+	inTok, outTok := 12, 8
+	inv.InputTokens = &inTok
+	inv.OutputTokens = &outTok
+	inv.ResponseModelName = "gpt-4-0613"
+	inv.ResponseID = "chatcmpl-xyz"
+
+	h.handler.StopLLM(inv)
+
+	// --- span assertions ---
+	ended := h.spans.Ended()
+	if len(ended) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(ended))
+	}
+	span := ended[0]
+	if got, want := span.Name(), "chat gpt-4"; got != want {
+		t.Errorf("span name = %q, want %q", got, want)
+	}
+	if span.Status().Code == codes.Error {
+		t.Errorf("span status = Error, want non-error; description=%q", span.Status().Description)
+	}
+	sa := attrMap(span.Attributes())
+	assertStr(t, sa, utilgenai.AttrGenAIOperationName, "chat")
+	assertStr(t, sa, utilgenai.AttrGenAIProviderName, "openai")
+	assertStr(t, sa, utilgenai.AttrGenAIRequestModel, "gpt-4")
+	assertStr(t, sa, utilgenai.AttrGenAIResponseModel, "gpt-4-0613")
+	assertInt(t, sa, utilgenai.AttrGenAIUsageInputTokens, 12)
+	assertInt(t, sa, utilgenai.AttrGenAIUsageOutputTokens, 8)
+
+	// --- metric assertions ---
+	dur := h.collectMetric(t, utilgenai.MetricGenAIClientOperationDuration)
+	if hist, ok := dur.Data.(metricdata.Histogram[float64]); !ok {
+		t.Errorf("%s is not a float64 histogram: %T", dur.Name, dur.Data)
+	} else if len(hist.DataPoints) == 0 || hist.DataPoints[0].Count == 0 {
+		t.Errorf("%s has no recorded data points", dur.Name)
+	}
+
+	tok := h.collectMetric(t, utilgenai.MetricGenAIClientTokenUsage)
+	hist, ok := tok.Data.(metricdata.Histogram[int64])
+	if !ok {
+		t.Fatalf("%s is not an int64 histogram: %T", tok.Name, tok.Data)
+	}
+	// Expect one data point for input tokens and one for output tokens.
+	if len(hist.DataPoints) < 2 {
+		t.Errorf("%s expected >=2 data points (input+output), got %d",
+			tok.Name, len(hist.DataPoints))
+	}
+	sawInput, sawOutput := false, false
+	for _, dp := range hist.DataPoints {
+		if v, ok := dp.Attributes.Value(attribute.Key(utilgenai.AttrGenAITokenType)); ok {
+			switch v.AsString() {
+			case "input":
+				sawInput = true
+			case "output":
+				sawOutput = true
+			}
+		}
+	}
+	if !sawInput || !sawOutput {
+		t.Errorf("%s missing token.type data points: input=%v output=%v",
+			tok.Name, sawInput, sawOutput)
+	}
+
+	// --- event assertions ---
+	names := h.logExport.eventNames()
+	if !contains(names, utilgenai.EventGenAIInferenceOperationDetails) {
+		t.Errorf("expected event %q to be emitted, got events: %v",
+			utilgenai.EventGenAIInferenceOperationDetails, names)
+	}
+}
+
+// TestLLMLifecycleFailure drives a failed invocation and asserts the span is
+// marked with an error status while the duration metric is still recorded.
+func TestLLMLifecycleFailure(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+
+	inv := utilgenai.NewLLMInvocation("gpt-4")
+	inv.Provider = "openai"
+
+	_ = h.handler.StartLLM(ctx, inv)
+
+	h.handler.FailLLM(inv, &utilgenai.Error{
+		Message: "Rate limit exceeded",
+		Type:    "RateLimitError",
+	})
+
+	ended := h.spans.Ended()
+	if len(ended) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(ended))
+	}
+	if code := ended[0].Status().Code; code != codes.Error {
+		t.Errorf("span status = %v, want Error", code)
+	}
+
+	// The duration metric should be recorded even on failure.
+	dur := h.collectMetric(t, utilgenai.MetricGenAIClientOperationDuration)
+	if hist, ok := dur.Data.(metricdata.Histogram[float64]); !ok || len(hist.DataPoints) == 0 {
+		t.Errorf("%s not recorded on failure", dur.Name)
+	}
+}
+
+// TestEventSuppressedWithoutOptIn verifies that no inference event is emitted
+// when experimental mode / event emission is not enabled.
+func TestEventSuppressedWithoutOptIn(t *testing.T) {
+	// Explicitly clear the opt-in envs for this test.
+	t.Setenv(utilgenai.EnvSemconvStabilityOptIn, "")
+	t.Setenv(utilgenai.EnvEmitEvent, "")
+
+	h := newHarness(t)
+	inv := utilgenai.NewLLMInvocation("gpt-4")
+	inv.Provider = "openai"
+	_ = h.handler.StartLLM(context.Background(), inv)
+	inTok, outTok := 1, 1
+	inv.InputTokens = &inTok
+	inv.OutputTokens = &outTok
+	h.handler.StopLLM(inv)
+
+	if names := h.logExport.eventNames(); len(names) != 0 {
+		t.Errorf("expected no events without opt-in, got: %v", names)
+	}
+}
+
+func assertStr(t *testing.T, m map[string]attribute.Value, key, want string) {
+	t.Helper()
+	v, ok := m[key]
+	if !ok {
+		t.Errorf("attribute %q missing", key)
+		return
+	}
+	if got := v.AsString(); got != want {
+		t.Errorf("attribute %q = %q, want %q", key, got, want)
+	}
+}
+
+func assertInt(t *testing.T, m map[string]attribute.Value, key string, want int64) {
+	t.Helper()
+	v, ok := m[key]
+	if !ok {
+		t.Errorf("attribute %q missing", key)
+		return
+	}
+	if got := v.AsInt64(); got != want {
+		t.Errorf("attribute %q = %d, want %d", key, got, want)
+	}
+}
+
+func contains(s []string, want string) bool {
+	for _, v := range s {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

`util-genai` currently has **no CI coverage** — no workflow builds or tests the module. This PR adds a dedicated CI pipeline plus an end-to-end integration test suite.

## Changes

### CI pipeline — `.github/workflows/util-genai.yml`
- Triggers on pushes/PRs that touch `util-genai/**` or the workflow file.
- Matrix on go **1.24** and **1.25**.
- Steps: `go build`, `go vet`, unit tests (`-race` + coverage) for the library, then the integration tests.
- Uses `GOFLAGS=-mod=mod` because `go.sum` and `vendor/` are git-ignored repo-wide, so modules are resolved from the network at build time.

### Integration tests — new module `util-genai/integration`
Kept as a **separate nested module** so the library itself retains an API-only dependency surface (no OTel SDK). The tests wire the `TelemetryHandler` to in-memory OpenTelemetry SDK exporters and assert the telemetry produced across a full invocation lifecycle:

- **Span**: name (`chat gpt-4`), operation/provider/model/response attributes, token usage attributes, non-error status.
- **Metrics**: `gen_ai.client.operation.duration` histogram recorded; `gen_ai.client.token.usage` has both `input` and `output` data points.
- **Failure path**: `FailLLM` marks the span with an error status while still recording the duration metric.
- **Event gating**: the `gen_ai.client.inference.operation.details` event is emitted only when the experimental opt-in (`OTEL_SEMCONV_STABILITY_OPT_IN` + `OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT`) is set, and suppressed otherwise.

## Verification

Ran locally against both toolchains:

- `go 1.24.10`: library `go build` / `go vet` / `go test -race`, and integration `go test -race` — all pass.
- `go 1.25.11`: same — all pass.