### PR TITLE
fix(db): set error.type on failed DB client metrics

### DIFF
--- a/pkg/inst-api-semconv/instrumenter/db/db_client_error.go
+++ b/pkg/inst-api-semconv/instrumenter/db/db_client_error.go
@@ -15,17 +15,63 @@
 package db
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 )
 
+func unwrapFmtWrapped(err error) error {
+	for err != nil {
+		t := reflect.TypeOf(err)
+		if t == nil {
+			break
+		}
+		name := t.String()
+		if name == "*fmt.wrapError" {
+			err = errors.Unwrap(err)
+		} else if name == "*errors.joinError" {
+			if je, ok := err.(interface{ Unwrap() []error }); ok {
+				errs := je.Unwrap()
+				if len(errs) > 0 {
+					err = errs[0]
+				} else {
+					break
+				}
+			} else {
+				break
+			}
+		} else {
+			break
+		}
+	}
+	return err
+}
+
 // NormalizeDBClientErrorType returns a low-cardinality error.type value for
-// failed DB client operations, matching otelc/HTTPClientErrorType style
-// (concrete Go type name). Empty when err is nil.
+// failed DB client operations, matching HTTP/otelc style (concrete Go type name).
+// Empty when err is nil.
 func NormalizeDBClientErrorType(err error) string {
 	if err == nil {
 		return ""
 	}
+
+	if et, ok := err.(interface{ ErrorType() string }); ok {
+		if s := et.ErrorType(); s != "" {
+			return s
+		}
+	}
+
+	err = unwrapFmtWrapped(err)
+	if err == nil {
+		return ""
+	}
+
+	if et, ok := err.(interface{ ErrorType() string }); ok {
+		if s := et.ErrorType(); s != "" {
+			return s
+		}
+	}
+
 	t := reflect.TypeOf(err)
 	if t == nil {
 		return ""

--- a/pkg/inst-api-semconv/instrumenter/db/db_client_error.go
+++ b/pkg/inst-api-semconv/instrumenter/db/db_client_error.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2024 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// NormalizeDBClientErrorType returns a low-cardinality error.type value for
+// failed DB client operations, matching otelc/HTTPClientErrorType style
+// (concrete Go type name). Empty when err is nil.
+func NormalizeDBClientErrorType(err error) string {
+	if err == nil {
+		return ""
+	}
+	t := reflect.TypeOf(err)
+	if t == nil {
+		return ""
+	}
+	if t.PkgPath() == "" && t.Name() == "" {
+		return t.String()
+	}
+	return fmt.Sprintf("%s.%s", t.PkgPath(), t.Name())
+}

--- a/pkg/inst-api-semconv/instrumenter/db/db_client_error.go
+++ b/pkg/inst-api-semconv/instrumenter/db/db_client_error.go
@@ -15,43 +15,21 @@
 package db
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
-)
 
-func unwrapFmtWrapped(err error) error {
-	for err != nil {
-		t := reflect.TypeOf(err)
-		if t == nil {
-			break
-		}
-		name := t.String()
-		if name == "*fmt.wrapError" {
-			err = errors.Unwrap(err)
-		} else if name == "*errors.joinError" {
-			if je, ok := err.(interface{ Unwrap() []error }); ok {
-				errs := je.Unwrap()
-				if len(errs) > 0 {
-					err = errs[0]
-				} else {
-					break
-				}
-			} else {
-				break
-			}
-		} else {
-			break
-		}
-	}
-	return err
-}
+	"github.com/alibaba/loongsuite-go/pkg/inst-api-semconv/instrumenter/utils"
+)
 
 // NormalizeDBClientErrorType returns a low-cardinality error.type value for
 // failed DB client operations, matching HTTP/otelc style (concrete Go type name).
 // Empty when err is nil.
 func NormalizeDBClientErrorType(err error) string {
 	if err == nil {
+		return ""
+	}
+	// Guard against typed nil (e.g. (*MyError)(nil) stored in error interface).
+	if v := reflect.ValueOf(err); v.Kind() == reflect.Ptr && v.IsNil() {
 		return ""
 	}
 
@@ -61,7 +39,7 @@ func NormalizeDBClientErrorType(err error) string {
 		}
 	}
 
-	err = unwrapFmtWrapped(err)
+	err = utils.UnwrapFmtWrapped(err)
 	if err == nil {
 		return ""
 	}

--- a/pkg/inst-api-semconv/instrumenter/db/db_client_error_test.go
+++ b/pkg/inst-api-semconv/instrumenter/db/db_client_error_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+import (
+	"errors"
+	"net"
+	"testing"
+)
+
+func TestNormalizeDBClientErrorType(t *testing.T) {
+	if got := NormalizeDBClientErrorType(nil); got != "" {
+		t.Fatalf("nil err should return empty, got %q", got)
+	}
+	if got := NormalizeDBClientErrorType(errors.New("x")); got != "*errors.errorString" {
+		t.Fatalf("unexpected error.type %q", got)
+	}
+	if got := NormalizeDBClientErrorType(&net.OpError{}); got != "*net.OpError" {
+		t.Fatalf("unexpected error.type %q", got)
+	}
+}

--- a/pkg/inst-api-semconv/instrumenter/db/db_client_error_test.go
+++ b/pkg/inst-api-semconv/instrumenter/db/db_client_error_test.go
@@ -16,9 +16,15 @@ package db
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"testing"
 )
+
+type customDBError struct{}
+
+func (customDBError) Error() string           { return "custom" }
+func (customDBError) ErrorType() string       { return "db.custom" }
 
 func TestNormalizeDBClientErrorType(t *testing.T) {
 	if got := NormalizeDBClientErrorType(nil); got != "" {
@@ -29,5 +35,14 @@ func TestNormalizeDBClientErrorType(t *testing.T) {
 	}
 	if got := NormalizeDBClientErrorType(&net.OpError{}); got != "*net.OpError" {
 		t.Fatalf("unexpected error.type %q", got)
+	}
+	if got := NormalizeDBClientErrorType(fmt.Errorf("dial: %w", &net.OpError{})); got != "*net.OpError" {
+		t.Fatalf("wrapped error should unwrap to *net.OpError, got %q", got)
+	}
+	if got := NormalizeDBClientErrorType(errors.Join(&net.OpError{}, errors.New("a"))); got != "*net.OpError" {
+		t.Fatalf("joined error should use first cause *net.OpError, got %q", got)
+	}
+	if got := NormalizeDBClientErrorType(customDBError{}); got != "db.custom" {
+		t.Fatalf("ErrorType() interface should take precedence, got %q", got)
 	}
 }

--- a/pkg/inst-api-semconv/instrumenter/db/db_client_error_test.go
+++ b/pkg/inst-api-semconv/instrumenter/db/db_client_error_test.go
@@ -23,12 +23,23 @@ import (
 
 type customDBError struct{}
 
-func (customDBError) Error() string           { return "custom" }
-func (customDBError) ErrorType() string       { return "db.custom" }
+func (customDBError) Error() string     { return "custom" }
+func (customDBError) ErrorType() string { return "db.custom" }
+
+type typedNilDBError struct {
+	kind string
+}
+
+func (e *typedNilDBError) Error() string     { return e.kind }
+func (e *typedNilDBError) ErrorType() string { return e.kind }
 
 func TestNormalizeDBClientErrorType(t *testing.T) {
 	if got := NormalizeDBClientErrorType(nil); got != "" {
 		t.Fatalf("nil err should return empty, got %q", got)
+	}
+	var typedNil error = (*typedNilDBError)(nil)
+	if got := NormalizeDBClientErrorType(typedNil); got != "" {
+		t.Fatalf("typed nil should return empty, got %q", got)
 	}
 	if got := NormalizeDBClientErrorType(errors.New("x")); got != "*errors.errorString" {
 		t.Fatalf("unexpected error.type %q", got)
@@ -44,5 +55,13 @@ func TestNormalizeDBClientErrorType(t *testing.T) {
 	}
 	if got := NormalizeDBClientErrorType(customDBError{}); got != "db.custom" {
 		t.Fatalf("ErrorType() interface should take precedence, got %q", got)
+	}
+}
+
+func TestNormalizeDBClientErrorTypeDoubleWrapped(t *testing.T) {
+	base := customDBError{}
+	wrapped := fmt.Errorf("app: %w", fmt.Errorf("db: %w", base))
+	if got := NormalizeDBClientErrorType(wrapped); got != "db.custom" {
+		t.Fatalf("expected db.custom after unwrap, got %q", got)
 	}
 }

--- a/pkg/inst-api-semconv/instrumenter/db/db_client_extractor.go
+++ b/pkg/inst-api-semconv/instrumenter/db/db_client_extractor.go
@@ -108,6 +108,13 @@ func (d *DbClientAttrsExtractor[REQUEST, RESPONSE, GETTER]) OnEnd(attrs []attrib
 	if dbNameSpace != "" {
 		attrs = append(attrs, attribute.KeyValue{Key: semconv.DBNamespaceKey, Value: attribute.StringValue(dbNameSpace)})
 	}
+	// Semconv Conditionally Required: error.type when the operation failed.
+	if errorType := NormalizeDBClientErrorType(err); errorType != "" {
+		attrs = append(attrs, attribute.KeyValue{
+			Key:   semconv.ErrorTypeKey,
+			Value: attribute.StringValue(errorType),
+		})
+	}
 	if d.Base.AttributesFilter != nil {
 		attrs = d.Base.AttributesFilter(attrs)
 	}

--- a/pkg/inst-api-semconv/instrumenter/db/db_client_extractor_test.go
+++ b/pkg/inst-api-semconv/instrumenter/db/db_client_extractor_test.go
@@ -16,7 +16,9 @@ package db
 
 import (
 	"context"
+	"errors"
 	"log"
+	"net"
 	"testing"
 
 	"github.com/alibaba/loongsuite-go/pkg/inst-api/utils"
@@ -112,6 +114,32 @@ func TestDbClientExtractorEnd(t *testing.T) {
 	}
 	if attrs[3].Key != semconv.ServerAddressKey || attrs[3].Value.AsString() != "test" {
 		t.Fatalf("db statement key should be test")
+	}
+	for _, attr := range attrs {
+		if attr.Key == semconv.ErrorTypeKey {
+			t.Fatalf("success path must not set error.type")
+		}
+	}
+}
+
+func TestDbClientExtractorEndSetsErrorType(t *testing.T) {
+	dbExtractor := DbClientAttrsExtractor[testRequest, testResponse, mongoAttrsGetter]{}
+	attrs := make([]attribute.KeyValue, 0)
+	parentContext := context.Background()
+	opErr := &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+	attrs, _ = dbExtractor.OnEnd(attrs, parentContext, testRequest{Name: "redis"}, testResponse{}, opErr)
+
+	var found bool
+	for _, attr := range attrs {
+		if attr.Key == semconv.ErrorTypeKey {
+			found = true
+			if attr.Value.AsString() != "*net.OpError" {
+				t.Fatalf("error.type should be *net.OpError, got %q", attr.Value.AsString())
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("failed DB operation must set error.type")
 	}
 }
 

--- a/pkg/inst-api-semconv/instrumenter/db/db_metrics.go
+++ b/pkg/inst-api-semconv/instrumenter/db/db_metrics.go
@@ -41,6 +41,7 @@ var dbMetricsConv = map[attribute.Key]bool{
 	semconv.DBOperationNameKey: true,
 	semconv.ServerAddressKey:   true,
 	semconv.DBNamespaceKey:     true,
+	semconv.ErrorTypeKey:       true,
 }
 
 var globalMeter metric.Meter

--- a/pkg/inst-api-semconv/instrumenter/db/db_metrics_test.go
+++ b/pkg/inst-api-semconv/instrumenter/db/db_metrics_test.go
@@ -88,6 +88,59 @@ func TestDbMetricAttributesShadower(t *testing.T) {
 	}
 }
 
+func TestDbClientMetricsRecordsErrorType(t *testing.T) {
+	reader := metric.NewManualReader()
+	res := resource.NewWithAttributes(
+		semconv.SchemaURL,
+		semconv.ServiceName("my-service"),
+		semconv.ServiceVersion("v0.1.0"),
+	)
+	mp := metric.NewMeterProvider(metric.WithResource(res), metric.WithReader(reader))
+	meter := mp.Meter("test-meter")
+	client, err := newDbClientMetric("test", meter)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	start := time.Now()
+	ctx = client.OnBeforeStart(ctx, start)
+	ctx = client.OnBeforeEnd(ctx, []attribute.KeyValue{
+		{Key: semconv.DBSystemNameKey, Value: attribute.StringValue("redis")},
+		{Key: semconv.DBOperationNameKey, Value: attribute.StringValue("get")},
+	}, start)
+	client.OnAfterStart(ctx, start)
+	client.OnAfterEnd(ctx, []attribute.KeyValue{
+		{Key: semconv.ErrorTypeKey, Value: attribute.StringValue("*net.OpError")},
+		{Key: "db.query.text", Value: attribute.StringValue("GET k")},
+	}, time.Now())
+
+	rm := &metricdata.ResourceMetrics{}
+	if err := reader.Collect(ctx, rm); err != nil {
+		t.Fatal(err)
+	}
+	hist, ok := rm.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[float64])
+	if !ok || len(hist.DataPoints) == 0 {
+		t.Fatalf("expected histogram datapoint")
+	}
+	attrs := hist.DataPoints[0].Attributes
+	var found bool
+	for _, kv := range attrs.ToSlice() {
+		if kv.Key == semconv.ErrorTypeKey {
+			found = true
+			if kv.Value.AsString() != "*net.OpError" {
+				t.Fatalf("unexpected error.type %q", kv.Value.AsString())
+			}
+		}
+		if kv.Key == "db.query.text" {
+			t.Fatalf("high-cardinality db.query.text must not be metric attribute")
+		}
+	}
+	if !found {
+		t.Fatalf("metric datapoint must include error.type")
+	}
+}
+
 func TestLazyDbClientMetrics(t *testing.T) {
 	reader := metric.NewManualReader()
 	res := resource.NewWithAttributes(

--- a/pkg/inst-api-semconv/instrumenter/db/db_metrics_test.go
+++ b/pkg/inst-api-semconv/instrumenter/db/db_metrics_test.go
@@ -66,13 +66,25 @@ func TestDbMetricAttributesShadower(t *testing.T) {
 	}, attribute.KeyValue{
 		Key:   semconv.ServerAddressKey,
 		Value: attribute.StringValue("abc"),
+	}, attribute.KeyValue{
+		Key:   semconv.ErrorTypeKey,
+		Value: attribute.StringValue("*net.OpError"),
 	})
 	n, attrs := utils.Shadow(attrs, dbMetricsConv)
-	if n != 3 {
+	if n != 4 {
 		panic("wrong shadow array")
 	}
-	if attrs[3].Key != "unknown" {
+	if attrs[4].Key != "unknown" {
 		panic("unknown should be the last attribute")
+	}
+	foundErrorType := false
+	for i := 0; i < n; i++ {
+		if attrs[i].Key == semconv.ErrorTypeKey {
+			foundErrorType = true
+		}
+	}
+	if !foundErrorType {
+		panic("error.type should be kept as a metric attribute")
 	}
 }
 

--- a/pkg/inst-api-semconv/instrumenter/http/http_client_error.go
+++ b/pkg/inst-api-semconv/instrumenter/http/http_client_error.go
@@ -15,37 +15,11 @@
 package http
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
-)
 
-func unwrapFmtWrapped(err error) error {
-	for err != nil {
-		t := reflect.TypeOf(err)
-		if t == nil {
-			break
-		}
-		name := t.String()
-		if name == "*fmt.wrapError" {
-			err = errors.Unwrap(err)
-		} else if name == "*errors.joinError" {
-			if je, ok := err.(interface{ Unwrap() []error }); ok {
-				errs := je.Unwrap()
-				if len(errs) > 0 {
-					err = errs[0]
-				} else {
-					break
-				}
-			} else {
-				break
-			}
-		} else {
-			break
-		}
-	}
-	return err
-}
+	"github.com/alibaba/loongsuite-go/pkg/inst-api-semconv/instrumenter/utils"
+)
 
 // NormalizeHTTPClientErrorType follows the upstream HTTPClientErrorType behavior
 // and uses the concrete Go error type as the error.type value.
@@ -62,7 +36,7 @@ func NormalizeHTTPClientErrorType(err error) string {
 	}
 
 	// 2. 解包 fmt.Errorf("%w") 和 errors.Join 产生的标准库包装类，获取底层具体错误
-	err = unwrapFmtWrapped(err)
+	err = utils.UnwrapFmtWrapped(err)
 	if err == nil {
 		return ""
 	}

--- a/pkg/inst-api-semconv/instrumenter/utils/error_unwrap.go
+++ b/pkg/inst-api-semconv/instrumenter/utils/error_unwrap.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2024 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"errors"
+	"reflect"
+)
+
+// UnwrapFmtWrapped peels fmt.Errorf("%w") and errors.Join wrappers until a
+// concrete error type is reached. Type names "*fmt.wrapError" and
+// "*errors.joinError" are unexported stdlib internals and may change across Go
+// versions.
+func UnwrapFmtWrapped(err error) error {
+	for err != nil {
+		t := reflect.TypeOf(err)
+		if t == nil {
+			break
+		}
+		name := t.String()
+		if name == "*fmt.wrapError" {
+			err = errors.Unwrap(err)
+		} else if name == "*errors.joinError" {
+			if je, ok := err.(interface{ Unwrap() []error }); ok {
+				errs := je.Unwrap()
+				if len(errs) > 0 {
+					err = errs[0]
+				} else {
+					break
+				}
+			} else {
+				break
+			}
+		} else {
+			break
+		}
+	}
+	return err
+}

--- a/pkg/inst-api-semconv/instrumenter/utils/error_unwrap_test.go
+++ b/pkg/inst-api-semconv/instrumenter/utils/error_unwrap_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2024 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"reflect"
+	"testing"
+)
+
+func TestUnwrapFmtWrappedNil(t *testing.T) {
+	if got := UnwrapFmtWrapped(nil); got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}
+
+func TestUnwrapFmtWrappedNoOp(t *testing.T) {
+	base := errors.New("boom")
+	if got := UnwrapFmtWrapped(base); got != base {
+		t.Fatalf("expected same error, got %v", got)
+	}
+}
+
+func TestUnwrapFmtWrappedSingleWrap(t *testing.T) {
+	base := &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+	wrapped := fmt.Errorf("middleware failed: %w", base)
+	if got := UnwrapFmtWrapped(wrapped); got != base {
+		t.Fatalf("expected %T, got %T", base, got)
+	}
+}
+
+func TestUnwrapFmtWrappedDoubleWrap(t *testing.T) {
+	base := &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+	wrapped := fmt.Errorf("app: %w", fmt.Errorf("db: %w", base))
+	if got := UnwrapFmtWrapped(wrapped); got != base {
+		t.Fatalf("expected %T, got %T", base, got)
+	}
+}
+
+func TestUnwrapFmtWrappedJoin(t *testing.T) {
+	base := &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+	joined := errors.Join(base, errors.New("other"))
+	if got := UnwrapFmtWrapped(joined); got != base {
+		t.Fatalf("expected %T, got %T", base, got)
+	}
+}
+
+// TestStdlibWrapperTypeNames pins the unexported stdlib type names that
+// UnwrapFmtWrapped relies on. Failures here typically mean a Go version
+// renamed *fmt.wrapError or *errors.joinError.
+func TestStdlibWrapperTypeNames(t *testing.T) {
+	wrapped := fmt.Errorf("wrap: %w", errors.New("inner"))
+	if got := reflect.TypeOf(wrapped).String(); got != "*fmt.wrapError" {
+		t.Fatalf("unexpected fmt wrap type name %q", got)
+	}
+	joined := errors.Join(errors.New("a"), errors.New("b"))
+	if got := reflect.TypeOf(joined).String(); got != "*errors.joinError" {
+		t.Fatalf("unexpected errors.Join type name %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Populate Conditionally Required `error.type` in `DbClientAttrsExtractor.OnEnd` when DB operations fail
- Allow `error.type` in `db.client.request.duration` metric attribute allowlist (`dbMetricsConv`)
- Align error-type normalization with HTTP/otelc (concrete Go type, unwrap `fmt.Errorf`/`errors.Join`)
- Extract shared `utils.UnwrapFmtWrapped` used by HTTP and DB paths
- Guard typed-nil errors so `NormalizeDBClientErrorType` does not panic or emit spurious `error.type`

Fixes #723

## Motivation
OTel [database metrics](https://opentelemetry.io/docs/specs/semconv/db/database-metrics/) requires `error.type` when an operation fails. Without it, failures and successes share the same metric labels and cannot be split for SLO/alerting. HTTP metrics in this repo already include `error.type`; DB path was inconsistent.

## Review follow-up (`3e33692`)
Addressed maintainer review feedback:

| Feedback | Change |
|----------|--------|
| Typed-nil panic risk | Guard with `reflect` so nil interface values / typed nils do not panic or emit a fake `error.type` |
| Duplicate unwrap helpers | Extract `utils.UnwrapFmtWrapped`; HTTP and DB both call the shared helper |
| Post-unwrap `ErrorType()` untested | Add test covering custom `ErrorType()` after double wrapping |
| Stdlib wrap/join type-name fragility | Pin `fmt.wrapError` / `errors.joinError` type names in tests for Go upgrade detection |

Still deferred (documented under Out of scope): pointer vs value `error.type` format; `GetErrorType` getter on `DbClientAttrsGetter`.

## Notes / merge dependency
- **Depends on #725** (fix for #721): Redis nil replies (`redis.Nil` / `rueidis.Nil` / redigo `ErrNil`) must not be passed into the instrumenter failure path. Otherwise cache misses get a false `error.type` and split `db.client.request.duration` time series. Prefer merging #725 before or with this PR.
- This PR does **not** hard-code Redis/SQL sentinel filtering inside `inst-api-semconv` (avoids pulling client SDKs into the shared module). Sentinel filtering belongs at each rule's `End` call site (#725).
- `sql.ErrNoRows` is not specially filtered here; `databasesql` hooks typically do not surface `Scan`-time `ErrNoRows` on the instrumented query path.

## Breaking change (metrics)
Adding `error.type` to `dbMetricsConv` changes the attribute set of `db.client.request.duration` for **all** DB instrumenters sharing this base module:
- Successful operations: no `error.type` dimension (same shape as before for success-only aggregations that ignore missing attrs, but success vs failure series diverge)
- Failed operations: new `error.type` label, splitting latency series by concrete Go error type

Existing dashboards, alerts, and SLOs that query `db.client.request.duration` without accounting for `error.type` may see apparent percentile shifts or broken aggregations. This matches existing HTTP client metric behavior; update queries/alerts to group or filter on `error.type` as needed. Call this out in release notes.

Metric name remains `db.client.request.duration` (semconv rename to `db.client.operation.duration` left as follow-up).

## Out of scope / follow-up
- Unify pointer vs value `error.type` string format with HTTP
- Add `GetErrorType` getter hook on `DbClientAttrsGetter` (HTTP already has one)

## Test plan
- [x] `go test ./inst-api-semconv/instrumenter/utils/ ./inst-api-semconv/instrumenter/http/ ./inst-api-semconv/instrumenter/db/ -race`
- [x] Success path does not set `error.type`
- [x] Failed path sets `error.type` (e.g. `*net.OpError`)
- [x] Typed nil returns empty `error.type`
- [x] Wrapped/joined errors unwrap to concrete type
- [x] Double-wrapped custom `ErrorType()` after unwrap
- [x] Stdlib wrap/join type name pins for Go upgrade detection
- [x] Metric datapoint retains `error.type` and excludes high-cardinality attrs like `db.query.text`