### PR TITLE
feat(db): add db.client.request.duration metrics for plugins missing DB metrics

### DIFF
--- a/docs/user/compatibility.md
+++ b/docs/user/compatibility.md
@@ -65,3 +65,37 @@ mapping of the `otel` to the supported OTel versions is as follows:
 | v1.8.2       | v1.40.0      | v0.65.0              |
 | v1.9.0       | v1.40.0      | v0.65.0              |
 | v1.10.0      | v1.40.0      | v0.65.0              |
+
+# Telemetry Migration Notes
+
+The following changes affect exported span attributes and metrics. Update dashboards
+and alerts accordingly when upgrading.
+
+## rueidis: `db.system.name` renamed to `redis`
+
+Previously, rueidis instrumentation set `db.system.name="rueidis"`. It now emits
+`db.system.name="redis"` to match OpenTelemetry semantic conventions and the
+goredis / redigo instrumentations.
+
+- **Impact:** Time series and span queries that filter on `db.system.name="rueidis"`
+  will stop matching after upgrade.
+- **Migration:** Change filters/aggregations to `db.system.name="redis"`. Distinguish
+  the client library via instrumentation scope name when needed.
+
+## Elasticsearch: `http.server.request.duration` replaced by `db.client.request.duration`
+
+The Elasticsearch plugin previously registered `HttpServerMetrics("elasticsearch.client")`,
+which incorrectly emitted `http.server.request.duration` for client operations. That
+listener is replaced by `DbClientMetrics("nosql.elasticsearch")`.
+
+| Before (incorrect) | After |
+| ------------------ | ----- |
+| `http.server.request.duration` from the ES plugin | `db.client.request.duration` with `db.system.name=elasticsearch` |
+
+- **Unchanged:** Transport-level `http.client.request.duration` from net/http
+  instrumentation continues to be emitted for the same requests.
+- **Migration:** Prefer `db.client.request.duration{db.system.name="elasticsearch"}`
+  for ES API latency. Prefer `http.client.request.duration` for HTTP transport
+  latency. Remove dashboards that relied on ES-scoped `http.server.request.duration`.
+- **No dual-write:** The previous `http.server.*` series on client spans was a
+  semconv mismatch and is not preserved during a deprecation window.

--- a/docs/zh/user/compatibility.md
+++ b/docs/zh/user/compatibility.md
@@ -54,3 +54,33 @@
 | v1.8.2   | v1.40.0   | v0.65.0           |
 | v1.9.0   | v1.40.0   | v0.65.0           |
 | v1.10.0  | v1.40.0   | v0.65.0           |
+
+# 遥测迁移说明
+
+以下变更会影响导出的 span 属性与指标。升级后请同步更新相关看板与告警。
+
+## rueidis：`db.system.name` 重命名为 `redis`
+
+此前 rueidis 埋点使用 `db.system.name="rueidis"`。现已改为 `db.system.name="redis"`，
+以符合 OpenTelemetry 语义约定，并与 goredis / redigo 保持一致。
+
+- **影响：** 依赖 `db.system.name="rueidis"` 过滤的时间序列与 span 查询在升级后将不再匹配。
+- **迁移：** 将过滤/聚合条件改为 `db.system.name="redis"`。如需区分客户端库，请使用
+  instrumentation scope name。
+
+## Elasticsearch：`http.server.request.duration` 替换为 `db.client.request.duration`
+
+Elasticsearch 插件此前错误注册了 `HttpServerMetrics("elasticsearch.client")`，会为
+客户端操作导出 `http.server.request.duration`。现已替换为
+`DbClientMetrics("nosql.elasticsearch")`。
+
+| 之前（不正确） | 之后 |
+| ------------- | ---- |
+| ES 插件导出的 `http.server.request.duration` | `db.client.request.duration`，且 `db.system.name=elasticsearch` |
+
+- **不变：** net/http 传输层的 `http.client.request.duration` 仍会为同一请求导出。
+- **迁移：** ES API 延迟请使用 `db.client.request.duration{db.system.name="elasticsearch"}`；
+  HTTP 传输延迟请使用 `http.client.request.duration`。依赖 ES 作用域下
+  `http.server.request.duration` 的看板需更新或移除。
+- **不做双写：** 原先在客户端 span 上导出的 `http.server.*` 不符合语义约定，不会在
+  弃用窗口内继续保留。

--- a/pkg/inst-api-semconv/instrumenter/db/db_metrics.go
+++ b/pkg/inst-api-semconv/instrumenter/db/db_metrics.go
@@ -108,8 +108,15 @@ func (h DbClientMetric) OnAfterStart(context context.Context, endTime time.Time)
 	return
 }
 
-func (h DbClientMetric) OnAfterEnd(context context.Context, endAttributes []attribute.KeyValue, endTime time.Time) {
-	mc := context.Value(h.key).(dbMetricContext)
+func (h DbClientMetric) OnAfterEnd(ctx context.Context, endAttributes []attribute.KeyValue, endTime time.Time) {
+	v := ctx.Value(h.key)
+	if v == nil {
+		return
+	}
+	mc, ok := v.(dbMetricContext)
+	if !ok {
+		return
+	}
 	startTime, startAttributes := mc.startTime, mc.startAttributes
 	// end attributes should be shadowed by AttrsShadower
 	if h.clientRequestDuration == nil {
@@ -123,6 +130,6 @@ func (h DbClientMetric) OnAfterEnd(context context.Context, endAttributes []attr
 	endAttributes = append(endAttributes, startAttributes...)
 	n, metricsAttrs := utils.Shadow(endAttributes, dbMetricsConv)
 	if h.clientRequestDuration != nil {
-		h.clientRequestDuration.Record(context, float64(endTime.Sub(startTime).Milliseconds()), metric.WithAttributeSet(attribute.NewSet(metricsAttrs[0:n]...)))
+		h.clientRequestDuration.Record(ctx, float64(endTime.Sub(startTime).Milliseconds()), metric.WithAttributeSet(attribute.NewSet(metricsAttrs[0:n]...)))
 	}
 }

--- a/pkg/inst-api-semconv/instrumenter/db/db_metrics.go
+++ b/pkg/inst-api-semconv/instrumenter/db/db_metrics.go
@@ -93,28 +93,30 @@ type dbMetricContext struct {
 	startAttributes []attribute.KeyValue
 }
 
-func (h DbClientMetric) OnBeforeStart(parentContext context.Context, startTime time.Time) context.Context {
+func (h *DbClientMetric) OnBeforeStart(parentContext context.Context, startTime time.Time) context.Context {
 	return parentContext
 }
 
-func (h DbClientMetric) OnBeforeEnd(ctx context.Context, startAttributes []attribute.KeyValue, startTime time.Time) context.Context {
+func (h *DbClientMetric) OnBeforeEnd(ctx context.Context, startAttributes []attribute.KeyValue, startTime time.Time) context.Context {
 	return context.WithValue(ctx, h.key, dbMetricContext{
 		startTime:       startTime,
 		startAttributes: startAttributes,
 	})
 }
 
-func (h DbClientMetric) OnAfterStart(context context.Context, endTime time.Time) {
+func (h *DbClientMetric) OnAfterStart(context context.Context, endTime time.Time) {
 	return
 }
 
-func (h DbClientMetric) OnAfterEnd(ctx context.Context, endAttributes []attribute.KeyValue, endTime time.Time) {
+func (h *DbClientMetric) OnAfterEnd(ctx context.Context, endAttributes []attribute.KeyValue, endTime time.Time) {
 	v := ctx.Value(h.key)
 	if v == nil {
+		log.Printf("DbClientMetric.OnAfterEnd: missing metric context for key %q; skipping record", h.key)
 		return
 	}
 	mc, ok := v.(dbMetricContext)
 	if !ok {
+		log.Printf("DbClientMetric.OnAfterEnd: invalid metric context type for key %q; skipping record", h.key)
 		return
 	}
 	startTime, startAttributes := mc.startTime, mc.startAttributes

--- a/pkg/inst-api-semconv/instrumenter/db/db_metrics.go
+++ b/pkg/inst-api-semconv/instrumenter/db/db_metrics.go
@@ -32,6 +32,7 @@ const db_client_request_duration = "db.client.request.duration"
 type DbClientMetric struct {
 	key                   attribute.Key
 	clientRequestDuration metric.Float64Histogram
+	initOnce              sync.Once
 }
 
 var mu sync.Mutex
@@ -65,12 +66,24 @@ func newDbClientMetric(key string, meter metric.Meter) (*DbClientMetric, error) 
 	m := &DbClientMetric{
 		key: attribute.Key(key),
 	}
-	d, err := newDbClientRequestDurationMeasures(meter)
+	var err error
+	m.initOnce.Do(func() {
+		m.clientRequestDuration, err = newDbClientRequestDurationMeasures(meter)
+	})
 	if err != nil {
 		return nil, err
 	}
-	m.clientRequestDuration = d
 	return m, nil
+}
+
+func (h *DbClientMetric) ensureDuration() {
+	h.initOnce.Do(func() {
+		var err error
+		h.clientRequestDuration, err = newDbClientRequestDurationMeasures(globalMeter)
+		if err != nil {
+			log.Printf("failed to create clientRequestDuration: %v\n", err)
+		}
+	})
 }
 
 func newDbClientRequestDurationMeasures(meter metric.Meter) (metric.Float64Histogram, error) {
@@ -122,14 +135,7 @@ func (h *DbClientMetric) OnAfterEnd(ctx context.Context, endAttributes []attribu
 	}
 	startTime, startAttributes := mc.startTime, mc.startAttributes
 	// end attributes should be shadowed by AttrsShadower
-	if h.clientRequestDuration == nil {
-		var err error
-		// second change to init the metric
-		h.clientRequestDuration, err = newDbClientRequestDurationMeasures(globalMeter)
-		if err != nil {
-			log.Printf("failed to create clientRequestDuration, err is %v\n", err)
-		}
-	}
+	h.ensureDuration()
 	endAttributes = append(endAttributes, startAttributes...)
 	n, metricsAttrs := utils.Shadow(endAttributes, dbMetricsConv)
 	if h.clientRequestDuration != nil {

--- a/pkg/inst-api-semconv/instrumenter/db/db_metrics_test.go
+++ b/pkg/inst-api-semconv/instrumenter/db/db_metrics_test.go
@@ -154,3 +154,20 @@ func TestDbClientMetricsMissingContext(t *testing.T) {
 	// End without matching OnBeforeEnd should not panic.
 	client.OnAfterEnd(context.Background(), nil, time.Now())
 }
+
+func TestDbClientMetricsWrongTypeContext(t *testing.T) {
+	reader := metric.NewManualReader()
+	res := resource.NewWithAttributes(
+		semconv.SchemaURL,
+		semconv.ServiceName("my-service"),
+		semconv.ServiceVersion("v0.1.0"),
+	)
+	mp := metric.NewMeterProvider(metric.WithResource(res), metric.WithReader(reader))
+	meter := mp.Meter("test-meter")
+	client, err := newDbClientMetric("test", meter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.WithValue(context.Background(), attribute.Key("test"), "not-a-dbMetricContext")
+	client.OnAfterEnd(ctx, nil, time.Now())
+}

--- a/pkg/inst-api-semconv/instrumenter/db/db_metrics_test.go
+++ b/pkg/inst-api-semconv/instrumenter/db/db_metrics_test.go
@@ -137,3 +137,20 @@ func TestNilMeter(t *testing.T) {
 		panic(err)
 	}
 }
+
+func TestDbClientMetricsMissingContext(t *testing.T) {
+	reader := metric.NewManualReader()
+	res := resource.NewWithAttributes(
+		semconv.SchemaURL,
+		semconv.ServiceName("my-service"),
+		semconv.ServiceVersion("v0.1.0"),
+	)
+	mp := metric.NewMeterProvider(metric.WithResource(res), metric.WithReader(reader))
+	meter := mp.Meter("test-meter")
+	client, err := newDbClientMetric("test", meter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// End without matching OnBeforeEnd should not panic.
+	client.OnAfterEnd(context.Background(), nil, time.Now())
+}

--- a/pkg/rules/clickhousev2/clickhouse_otel_instrumenter.go
+++ b/pkg/rules/clickhousev2/clickhouse_otel_instrumenter.go
@@ -62,6 +62,7 @@ func BuildClickhouseInstrumenter() instrumenter.Instrumenter[clickhouseRequest, 
 	getter := clickhouseAttrsGetter{}
 	return builder.Init().SetSpanNameExtractor(&db.DBSpanNameExtractor[clickhouseRequest]{Getter: getter}).SetSpanKindExtractor(&instrumenter.AlwaysClientExtractor[clickhouseRequest]{}).
 		AddAttributesExtractor(&db.DbClientAttrsExtractor[clickhouseRequest, any, clickhouseAttrsGetter]{Base: db.DbClientCommonAttrsExtractor[clickhouseRequest, any, clickhouseAttrsGetter]{Getter: getter}}).
+		AddOperationListeners(db.DbClientMetrics("database.clickhouse")).
 		SetInstrumentationScope(instrumentation.Scope{
 			Name:    utils.CLICKHOUSE_V2_SCOPE_NAME,
 			Version: version.Tag,

--- a/pkg/rules/elasticsearch/es_otel_instrumenter.go
+++ b/pkg/rules/elasticsearch/es_otel_instrumenter.go
@@ -16,7 +16,6 @@ package elasticsearch
 
 import (
 	"github.com/alibaba/loongsuite-go/pkg/inst-api-semconv/instrumenter/db"
-	"github.com/alibaba/loongsuite-go/pkg/inst-api-semconv/instrumenter/http"
 	"github.com/alibaba/loongsuite-go/pkg/inst-api/instrumenter"
 	"github.com/alibaba/loongsuite-go/pkg/inst-api/utils"
 	"github.com/alibaba/loongsuite-go/pkg/inst-api/version"
@@ -63,7 +62,7 @@ func BuildElasticSearchInstrumenter() instrumenter.Instrumenter[*esRequest, inte
 	builder := instrumenter.Builder[*esRequest, any]{}
 	getter := elasticSearchGetter{}
 	return builder.Init().SetSpanNameExtractor(&db.DBSpanNameExtractor[*esRequest]{Getter: elasticSearchGetter{}}).SetSpanKindExtractor(&instrumenter.AlwaysClientExtractor[*esRequest]{}).
-		AddOperationListeners(http.HttpServerMetrics("elasticsearch.client")).
+		AddOperationListeners(db.DbClientMetrics("nosql.elasticsearch")).
 		SetInstrumentationScope(instrumentation.Scope{
 			Name:    utils.ELASTICSEARCH_SCOPE_NAME,
 			Version: version.Tag,

--- a/pkg/rules/gocql/gocql_otel_instrumenter.go
+++ b/pkg/rules/gocql/gocql_otel_instrumenter.go
@@ -62,6 +62,7 @@ func BuildGocqlInstrumenter() instrumenter.Instrumenter[gocqlRequest, interface{
 	getter := gogpAttrsGetter{}
 	return builder.Init().SetSpanNameExtractor(&db.DBSpanNameExtractor[gocqlRequest]{Getter: getter}).SetSpanKindExtractor(&instrumenter.AlwaysClientExtractor[gocqlRequest]{}).
 		AddAttributesExtractor(&db.DbClientAttrsExtractor[gocqlRequest, any, gogpAttrsGetter]{Base: db.DbClientCommonAttrsExtractor[gocqlRequest, any, gogpAttrsGetter]{Getter: getter}}).
+		AddOperationListeners(db.DbClientMetrics("nosql.gocql")).
 		SetInstrumentationScope(instrumentation.Scope{
 			Name:    utils.GOCQL_SCOPE_NAME,
 			Version: version.Tag,

--- a/pkg/rules/gopg/gopg_otel_instrumenter.go
+++ b/pkg/rules/gopg/gopg_otel_instrumenter.go
@@ -62,6 +62,7 @@ func BuildGopgInstrumenter() instrumenter.Instrumenter[gopgRequest, interface{}]
 	getter := gogpAttrsGetter{}
 	return builder.Init().SetSpanNameExtractor(&db.DBSpanNameExtractor[gopgRequest]{Getter: getter}).SetSpanKindExtractor(&instrumenter.AlwaysClientExtractor[gopgRequest]{}).
 		AddAttributesExtractor(&db.DbClientAttrsExtractor[gopgRequest, any, gogpAttrsGetter]{Base: db.DbClientCommonAttrsExtractor[gopgRequest, any, gogpAttrsGetter]{Getter: getter}}).
+		AddOperationListeners(db.DbClientMetrics("database.gopg")).
 		SetInstrumentationScope(instrumentation.Scope{
 			Name:    utils.GOPG_SCOPE_NAME,
 			Version: version.Tag,

--- a/pkg/rules/rueidisgo/rueidis_otel_instrumenter.go
+++ b/pkg/rules/rueidisgo/rueidis_otel_instrumenter.go
@@ -24,7 +24,7 @@ type goRueidisAttrsGetter struct {
 }
 
 func (d goRueidisAttrsGetter) GetSystem(request *goRueidisRequest) string {
-	return "rueidis"
+	return "redis"
 }
 
 func (d goRueidisAttrsGetter) GetServerAddress(request *goRueidisRequest) string {

--- a/pkg/rules/rueidisgo/rueidis_otel_instrumenter.go
+++ b/pkg/rules/rueidisgo/rueidis_otel_instrumenter.go
@@ -68,5 +68,6 @@ func BuildGoRueidisOtelInstrumenter() instrumenter.Instrumenter[*goRueidisReques
 	getter := goRueidisAttrsGetter{}
 	return builder.Init().SetSpanNameExtractor(&db.DBSpanNameExtractor[*goRueidisRequest]{Getter: getter}).SetSpanKindExtractor(&instrumenter.AlwaysClientExtractor[*goRueidisRequest]{}).
 		AddAttributesExtractor(&db.DbClientAttrsExtractor[*goRueidisRequest, any, db.DbClientAttrsGetter[*goRueidisRequest]]{Base: db.DbClientCommonAttrsExtractor[*goRueidisRequest, any, db.DbClientAttrsGetter[*goRueidisRequest]]{Getter: getter}}).
+		AddOperationListeners(db.DbClientMetrics("nosql.rueidis")).
 		BuildInstrumenter()
 }

--- a/test/clickhousev2/v2.13.0/test_clickhousev2_crud.go
+++ b/test/clickhousev2/v2.13.0/test_clickhousev2_crud.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"context"
+	"log"
+	"os"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/alibaba/loongsuite-go/test/verifier"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	"log"
-	"os"
 )
 
 var con driver.Conn
@@ -127,4 +129,31 @@ func main() {
 		verifier.VerifyDbAttributes(stubs[6][0], "SERVER_VERSION", "clickhouse", addr, "SERVER_VERSION", "SERVER_VERSION", "", nil)
 		verifier.VerifyDbAttributes(stubs[7][0], "PING", "clickhouse", addr, "PING", "PING", "", nil)
 	}, 1)
+	verifier.WaitAndAssertMetrics(map[string]func(metricdata.ResourceMetrics){
+		"db.client.request.duration": func(mrs metricdata.ResourceMetrics) {
+			if len(mrs.ScopeMetrics) <= 0 {
+				panic("No db.client.request.duration metrics received!")
+			}
+			point := mrs.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[float64])
+			if len(point.DataPoints) <= 0 {
+				panic("db.client.request.duration has no datapoints")
+			}
+			found := false
+			for _, dp := range point.DataPoints {
+				if dp.Count <= 0 {
+					continue
+				}
+				attrs := dp.Attributes.ToSlice()
+				if verifier.GetAttribute(attrs, "db.system.name").AsString() == "clickhouse" &&
+					verifier.GetAttribute(attrs, "db.operation.name").AsString() == "EXEC" &&
+					verifier.GetAttribute(attrs, "server.address").AsString() == addr {
+					found = true
+					break
+				}
+			}
+			if !found {
+				panic("db.client.request.duration missing EXEC datapoint for clickhouse")
+			}
+		},
+	})
 }

--- a/test/clickhousev2/v2.42.0/test_clickhousev2_crud.go
+++ b/test/clickhousev2/v2.42.0/test_clickhousev2_crud.go
@@ -16,12 +16,14 @@ package main
 
 import (
 	"context"
+	"log"
+	"os"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/alibaba/loongsuite-go/test/verifier"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	"log"
-	"os"
 )
 
 var con driver.Conn
@@ -141,4 +143,31 @@ func main() {
 		verifier.VerifyDbAttributes(stubs[6][0], "SERVER_VERSION", "clickhouse", addr, "SERVER_VERSION", "SERVER_VERSION", "", nil)
 		verifier.VerifyDbAttributes(stubs[7][0], "PING", "clickhouse", addr, "PING", "PING", "", nil)
 	}, 1)
+	verifier.WaitAndAssertMetrics(map[string]func(metricdata.ResourceMetrics){
+		"db.client.request.duration": func(mrs metricdata.ResourceMetrics) {
+			if len(mrs.ScopeMetrics) <= 0 {
+				panic("No db.client.request.duration metrics received!")
+			}
+			point := mrs.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[float64])
+			if len(point.DataPoints) <= 0 {
+				panic("db.client.request.duration has no datapoints")
+			}
+			found := false
+			for _, dp := range point.DataPoints {
+				if dp.Count <= 0 {
+					continue
+				}
+				attrs := dp.Attributes.ToSlice()
+				if verifier.GetAttribute(attrs, "db.system.name").AsString() == "clickhouse" &&
+					verifier.GetAttribute(attrs, "db.operation.name").AsString() == "EXEC" &&
+					verifier.GetAttribute(attrs, "server.address").AsString() == addr {
+					found = true
+					break
+				}
+			}
+			if !found {
+				panic("db.client.request.duration missing EXEC datapoint for clickhouse")
+			}
+		},
+	})
 }

--- a/test/elasticsearch/v8.4.0/test_es_metrics.go
+++ b/test/elasticsearch/v8.4.0/test_es_metrics.go
@@ -15,10 +15,10 @@
 package main
 
 import (
-	"strconv"
-
 	"log"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/alibaba/loongsuite-go/test/verifier"
 	"github.com/elastic/go-elasticsearch/v8"
@@ -66,13 +66,15 @@ func main() {
 					continue
 				}
 				attrs := dp.Attributes.ToSlice()
-				if verifier.GetAttribute(attrs, "db.system.name").AsString() == "elasticsearch" {
+				if verifier.GetAttribute(attrs, "db.system.name").AsString() == "elasticsearch" &&
+					verifier.GetAttribute(attrs, "db.operation.name").AsString() == "put" &&
+					strings.Contains(verifier.GetAttribute(attrs, "server.address").AsString(), "127.0.0.1") {
 					found = true
 					break
 				}
 			}
 			if !found {
-				panic("db.client.request.duration missing elasticsearch datapoint")
+				panic("db.client.request.duration missing elasticsearch put datapoint")
 			}
 		},
 		// net/http client instrumentation still records transport-level latency.
@@ -81,10 +83,24 @@ func main() {
 				panic("No http.client.request.duration metrics received!")
 			}
 			point := mrs.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[float64])
-			if point.DataPoints[0].Count <= 0 {
-				panic("http.client.request.duration metrics count is not positive, actually " + strconv.Itoa(int(point.DataPoints[0].Count)))
+			if len(point.DataPoints) == 0 {
+				panic("http.client.request.duration has no datapoints")
 			}
-			verifier.VerifyHttpClientMetricsAttributes(point.DataPoints[0].Attributes.ToSlice(), "PUT", "", "", "http", "1.1", port, 200)
+			found := false
+			for _, dp := range point.DataPoints {
+				if dp.Count <= 0 {
+					continue
+				}
+				attrs := dp.Attributes.ToSlice()
+				if verifier.GetAttribute(attrs, "http.request.method").AsString() == "PUT" {
+					verifier.VerifyHttpClientMetricsAttributes(attrs, "PUT", "", "", "http", "1.1", port, 200)
+					found = true
+					break
+				}
+			}
+			if !found {
+				panic("http.client.request.duration missing PUT datapoint")
+			}
 		},
 	})
 }

--- a/test/elasticsearch/v8.4.0/test_es_metrics.go
+++ b/test/elasticsearch/v8.4.0/test_es_metrics.go
@@ -57,12 +57,22 @@ func main() {
 				panic("No db.client.request.duration metrics received!")
 			}
 			point := mrs.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[float64])
-			if point.DataPoints[0].Count <= 0 {
-				panic("db.client.request.duration metrics count is not positive, actually " + strconv.Itoa(int(point.DataPoints[0].Count)))
+			if len(point.DataPoints) == 0 {
+				panic("db.client.request.duration has no datapoints")
 			}
-			attrs := point.DataPoints[0].Attributes.ToSlice()
-			if verifier.GetAttribute(attrs, "db.system.name").AsString() != "elasticsearch" {
-				panic("expected db.system.name=elasticsearch")
+			found := false
+			for _, dp := range point.DataPoints {
+				if dp.Count <= 0 {
+					continue
+				}
+				attrs := dp.Attributes.ToSlice()
+				if verifier.GetAttribute(attrs, "db.system.name").AsString() == "elasticsearch" {
+					found = true
+					break
+				}
+			}
+			if !found {
+				panic("db.client.request.duration missing elasticsearch datapoint")
 			}
 		},
 		// net/http client instrumentation still records transport-level latency.

--- a/test/elasticsearch/v8.4.0/test_es_metrics.go
+++ b/test/elasticsearch/v8.4.0/test_es_metrics.go
@@ -52,6 +52,20 @@ func main() {
 	}
 
 	verifier.WaitAndAssertMetrics(map[string]func(metricdata.ResourceMetrics){
+		"db.client.request.duration": func(mrs metricdata.ResourceMetrics) {
+			if len(mrs.ScopeMetrics) <= 0 {
+				panic("No db.client.request.duration metrics received!")
+			}
+			point := mrs.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[float64])
+			if point.DataPoints[0].Count <= 0 {
+				panic("db.client.request.duration metrics count is not positive, actually " + strconv.Itoa(int(point.DataPoints[0].Count)))
+			}
+			attrs := point.DataPoints[0].Attributes.ToSlice()
+			if verifier.GetAttribute(attrs, "db.system.name").AsString() != "elasticsearch" {
+				panic("expected db.system.name=elasticsearch")
+			}
+		},
+		// net/http client instrumentation still records transport-level latency.
 		"http.client.request.duration": func(mrs metricdata.ResourceMetrics) {
 			if len(mrs.ScopeMetrics) <= 0 {
 				panic("No http.client.request.duration metrics received!")

--- a/test/elasticsearch/v8.5.0/test_es_typedclient_metrics.go
+++ b/test/elasticsearch/v8.5.0/test_es_typedclient_metrics.go
@@ -58,12 +58,22 @@ func main() {
 				panic("No db.client.request.duration metrics received!")
 			}
 			point := mrs.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[float64])
-			if point.DataPoints[0].Count <= 0 {
-				panic("db.client.request.duration metrics count is not positive, actually " + strconv.Itoa(int(point.DataPoints[0].Count)))
+			if len(point.DataPoints) == 0 {
+				panic("db.client.request.duration has no datapoints")
 			}
-			attrs := point.DataPoints[0].Attributes.ToSlice()
-			if verifier.GetAttribute(attrs, "db.system.name").AsString() != "elasticsearch" {
-				panic("expected db.system.name=elasticsearch")
+			found := false
+			for _, dp := range point.DataPoints {
+				if dp.Count <= 0 {
+					continue
+				}
+				attrs := dp.Attributes.ToSlice()
+				if verifier.GetAttribute(attrs, "db.system.name").AsString() == "elasticsearch" {
+					found = true
+					break
+				}
+			}
+			if !found {
+				panic("db.client.request.duration missing elasticsearch datapoint")
 			}
 		},
 		// net/http client instrumentation still records transport-level latency.

--- a/test/elasticsearch/v8.5.0/test_es_typedclient_metrics.go
+++ b/test/elasticsearch/v8.5.0/test_es_typedclient_metrics.go
@@ -19,6 +19,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/alibaba/loongsuite-go/test/verifier"
@@ -67,13 +68,15 @@ func main() {
 					continue
 				}
 				attrs := dp.Attributes.ToSlice()
-				if verifier.GetAttribute(attrs, "db.system.name").AsString() == "elasticsearch" {
+				if verifier.GetAttribute(attrs, "db.system.name").AsString() == "elasticsearch" &&
+					verifier.GetAttribute(attrs, "db.operation.name").AsString() == "put" &&
+					strings.Contains(verifier.GetAttribute(attrs, "server.address").AsString(), "127.0.0.1") {
 					found = true
 					break
 				}
 			}
 			if !found {
-				panic("db.client.request.duration missing elasticsearch datapoint")
+				panic("db.client.request.duration missing elasticsearch put datapoint")
 			}
 		},
 		// net/http client instrumentation still records transport-level latency.
@@ -82,10 +85,24 @@ func main() {
 				panic("No http.client.request.duration metrics received!")
 			}
 			point := mrs.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[float64])
-			if point.DataPoints[0].Count <= 0 {
-				panic("http.client.request.duration metrics count is not positive, actually " + strconv.Itoa(int(point.DataPoints[0].Count)))
+			if len(point.DataPoints) == 0 {
+				panic("http.client.request.duration has no datapoints")
 			}
-			verifier.VerifyHttpClientMetricsAttributes(point.DataPoints[0].Attributes.ToSlice(), "PUT", "", "", "http", "1.1", port, 200)
+			found := false
+			for _, dp := range point.DataPoints {
+				if dp.Count <= 0 {
+					continue
+				}
+				attrs := dp.Attributes.ToSlice()
+				if verifier.GetAttribute(attrs, "http.request.method").AsString() == "PUT" {
+					verifier.VerifyHttpClientMetricsAttributes(attrs, "PUT", "", "", "http", "1.1", port, 200)
+					found = true
+					break
+				}
+			}
+			if !found {
+				panic("http.client.request.duration missing PUT datapoint")
+			}
 		},
 	})
 }

--- a/test/elasticsearch/v8.5.0/test_es_typedclient_metrics.go
+++ b/test/elasticsearch/v8.5.0/test_es_typedclient_metrics.go
@@ -53,6 +53,20 @@ func main() {
 		panic(err)
 	}
 	verifier.WaitAndAssertMetrics(map[string]func(metricdata.ResourceMetrics){
+		"db.client.request.duration": func(mrs metricdata.ResourceMetrics) {
+			if len(mrs.ScopeMetrics) <= 0 {
+				panic("No db.client.request.duration metrics received!")
+			}
+			point := mrs.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[float64])
+			if point.DataPoints[0].Count <= 0 {
+				panic("db.client.request.duration metrics count is not positive, actually " + strconv.Itoa(int(point.DataPoints[0].Count)))
+			}
+			attrs := point.DataPoints[0].Attributes.ToSlice()
+			if verifier.GetAttribute(attrs, "db.system.name").AsString() != "elasticsearch" {
+				panic("expected db.system.name=elasticsearch")
+			}
+		},
+		// net/http client instrumentation still records transport-level latency.
 		"http.client.request.duration": func(mrs metricdata.ResourceMetrics) {
 			if len(mrs.ScopeMetrics) <= 0 {
 				panic("No http.client.request.duration metrics received!")

--- a/test/gocql/v1.3.0/test_gocql_crud.go
+++ b/test/gocql/v1.3.0/test_gocql_crud.go
@@ -15,11 +15,13 @@
 package main
 
 import (
-	"github.com/alibaba/loongsuite-go/test/verifier"
-	"github.com/gocql/gocql"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"log"
 	"os"
+
+	"github.com/alibaba/loongsuite-go/test/verifier"
+	"github.com/gocql/gocql"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 var session *gocql.Session
@@ -101,4 +103,31 @@ func main() {
 		verifier.VerifyDbAttributes(stubs[6][0], "DROP TABLE", "cassandra", host, "DROP table IF EXISTS cassandra.shopping_cart;", "DROP TABLE", "", nil)
 		verifier.VerifyDbAttributes(stubs[7][0], "DROP KEYSPACE", "cassandra", host, "DROP KEYSPACE IF EXISTS cassandra;", "DROP KEYSPACE", "", nil)
 	}, 1)
+	verifier.WaitAndAssertMetrics(map[string]func(metricdata.ResourceMetrics){
+		"db.client.request.duration": func(mrs metricdata.ResourceMetrics) {
+			if len(mrs.ScopeMetrics) <= 0 {
+				panic("No db.client.request.duration metrics received!")
+			}
+			point := mrs.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[float64])
+			if len(point.DataPoints) <= 0 {
+				panic("db.client.request.duration has no datapoints")
+			}
+			found := false
+			for _, dp := range point.DataPoints {
+				if dp.Count <= 0 {
+					continue
+				}
+				attrs := dp.Attributes.ToSlice()
+				if verifier.GetAttribute(attrs, "db.system.name").AsString() == "cassandra" &&
+					verifier.GetAttribute(attrs, "db.operation.name").AsString() == "SELECT" &&
+					verifier.GetAttribute(attrs, "server.address").AsString() == host {
+					found = true
+					break
+				}
+			}
+			if !found {
+				panic("db.client.request.duration missing SELECT datapoint for cassandra")
+			}
+		},
+	})
 }

--- a/test/gocql/v1.7.0/test_gocql_crud.go
+++ b/test/gocql/v1.7.0/test_gocql_crud.go
@@ -15,11 +15,13 @@
 package main
 
 import (
-	"github.com/alibaba/loongsuite-go/test/verifier"
-	"github.com/gocql/gocql"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"log"
 	"os"
+
+	"github.com/alibaba/loongsuite-go/test/verifier"
+	"github.com/gocql/gocql"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 var session *gocql.Session
@@ -101,4 +103,31 @@ func main() {
 		verifier.VerifyDbAttributes(stubs[6][0], "DROP TABLE", "cassandra", host, "DROP table IF EXISTS cassandra.shopping_cart;", "DROP TABLE", "", nil)
 		verifier.VerifyDbAttributes(stubs[7][0], "DROP KEYSPACE", "cassandra", host, "DROP KEYSPACE IF EXISTS cassandra;", "DROP KEYSPACE", "", nil)
 	}, 1)
+	verifier.WaitAndAssertMetrics(map[string]func(metricdata.ResourceMetrics){
+		"db.client.request.duration": func(mrs metricdata.ResourceMetrics) {
+			if len(mrs.ScopeMetrics) <= 0 {
+				panic("No db.client.request.duration metrics received!")
+			}
+			point := mrs.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[float64])
+			if len(point.DataPoints) <= 0 {
+				panic("db.client.request.duration has no datapoints")
+			}
+			found := false
+			for _, dp := range point.DataPoints {
+				if dp.Count <= 0 {
+					continue
+				}
+				attrs := dp.Attributes.ToSlice()
+				if verifier.GetAttribute(attrs, "db.system.name").AsString() == "cassandra" &&
+					verifier.GetAttribute(attrs, "db.operation.name").AsString() == "SELECT" &&
+					verifier.GetAttribute(attrs, "server.address").AsString() == host {
+					found = true
+					break
+				}
+			}
+			if !found {
+				panic("db.client.request.duration missing SELECT datapoint for cassandra")
+			}
+		},
+	})
 }

--- a/test/gopg/v10.10.0/test_gopg_crud.go
+++ b/test/gopg/v10.10.0/test_gopg_crud.go
@@ -15,12 +15,14 @@
 package main
 
 import (
+	"log"
+	"os"
+
 	"github.com/alibaba/loongsuite-go/test/verifier"
 	"github.com/go-pg/pg/v10"
 	"github.com/go-pg/pg/v10/orm"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	"log"
-	"os"
 )
 
 var db *pg.DB
@@ -70,8 +72,9 @@ func TestDropTable() {
 }
 
 func main() {
+	addr := "127.0.0.1:" + os.Getenv("POSTGRES_PORT")
 	db = pg.Connect(&pg.Options{
-		Addr:     "127.0.0.1:" + os.Getenv("POSTGRES_PORT"),
+		Addr:     addr,
 		User:     "postgres",
 		Password: "postgres",
 		Database: "postgres",
@@ -90,4 +93,31 @@ func main() {
 		verifier.VerifyDbAttributes(stubs[4][0], "DELETE", "postgresql", "127.0.0.1", "DELETE FROM \"users\" AS \"user\" WHERE \"user\".\"id\" = '1'", "DELETE", "", nil)
 		verifier.VerifyDbAttributes(stubs[5][0], "DROP TABLE", "postgresql", "127.0.0.1", "DROP TABLE \"users\"", "DROP TABLE", "", nil)
 	}, 1)
+	verifier.WaitAndAssertMetrics(map[string]func(metricdata.ResourceMetrics){
+		"db.client.request.duration": func(mrs metricdata.ResourceMetrics) {
+			if len(mrs.ScopeMetrics) <= 0 {
+				panic("No db.client.request.duration metrics received!")
+			}
+			point := mrs.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[float64])
+			if len(point.DataPoints) <= 0 {
+				panic("db.client.request.duration has no datapoints")
+			}
+			found := false
+			for _, dp := range point.DataPoints {
+				if dp.Count <= 0 {
+					continue
+				}
+				attrs := dp.Attributes.ToSlice()
+				if verifier.GetAttribute(attrs, "db.system.name").AsString() == "postgresql" &&
+					verifier.GetAttribute(attrs, "db.operation.name").AsString() == "SELECT" &&
+					verifier.GetAttribute(attrs, "server.address").AsString() == addr {
+					found = true
+					break
+				}
+			}
+			if !found {
+				panic("db.client.request.duration missing SELECT datapoint for postgresql")
+			}
+		},
+	})
 }

--- a/test/gopg/v10.14.0/test_gopg_crud.go
+++ b/test/gopg/v10.14.0/test_gopg_crud.go
@@ -15,12 +15,14 @@
 package main
 
 import (
+	"log"
+	"os"
+
 	"github.com/alibaba/loongsuite-go/test/verifier"
 	"github.com/go-pg/pg/v10"
 	"github.com/go-pg/pg/v10/orm"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	"log"
-	"os"
 )
 
 var db *pg.DB
@@ -70,8 +72,9 @@ func TestDropTable() {
 }
 
 func main() {
+	addr := "127.0.0.1:" + os.Getenv("POSTGRES_PORT")
 	db = pg.Connect(&pg.Options{
-		Addr:     "127.0.0.1:" + os.Getenv("POSTGRES_PORT"),
+		Addr:     addr,
 		User:     "postgres",
 		Password: "postgres",
 		Database: "postgres",
@@ -90,4 +93,31 @@ func main() {
 		verifier.VerifyDbAttributes(stubs[4][0], "DELETE", "postgresql", "127.0.0.1", "DELETE FROM \"users\" AS \"user\" WHERE \"user\".\"id\" = '1'", "DELETE", "", nil)
 		verifier.VerifyDbAttributes(stubs[5][0], "DROP TABLE", "postgresql", "127.0.0.1", "DROP TABLE \"users\"", "DROP TABLE", "", nil)
 	}, 1)
+	verifier.WaitAndAssertMetrics(map[string]func(metricdata.ResourceMetrics){
+		"db.client.request.duration": func(mrs metricdata.ResourceMetrics) {
+			if len(mrs.ScopeMetrics) <= 0 {
+				panic("No db.client.request.duration metrics received!")
+			}
+			point := mrs.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[float64])
+			if len(point.DataPoints) <= 0 {
+				panic("db.client.request.duration has no datapoints")
+			}
+			found := false
+			for _, dp := range point.DataPoints {
+				if dp.Count <= 0 {
+					continue
+				}
+				attrs := dp.Attributes.ToSlice()
+				if verifier.GetAttribute(attrs, "db.system.name").AsString() == "postgresql" &&
+					verifier.GetAttribute(attrs, "db.operation.name").AsString() == "SELECT" &&
+					verifier.GetAttribute(attrs, "server.address").AsString() == addr {
+					found = true
+					break
+				}
+			}
+			if !found {
+				panic("db.client.request.duration missing SELECT datapoint for postgresql")
+			}
+		},
+	})
 }

--- a/test/rueidis/v1.0.30/test_basic.go
+++ b/test/rueidis/v1.0.30/test_basic.go
@@ -3,19 +3,22 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/alibaba/loongsuite-go/test/verifier"
-	"github.com/redis/rueidis"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	"go.opentelemetry.io/otel/trace"
 	"log"
 	"os"
 	"time"
+
+	"github.com/alibaba/loongsuite-go/test/verifier"
+	"github.com/redis/rueidis"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func main() {
+	redisAddr := "localhost:" + os.Getenv("REDIS_PORT")
 	// 创建 rueidis 客户端
 	client, err := rueidis.NewClient(rueidis.ClientOption{
-		InitAddress: []string{"localhost:" + os.Getenv("REDIS_PORT")}, // Redis 地址
+		InitAddress: []string{redisAddr}, // Redis 地址
 		// Username:  "default",                    // 可选：用户名
 		Password: "", // no password set
 		// SelectDB:  0,                            // 可选：选择 DB
@@ -183,4 +186,31 @@ func main() {
 		verifier.Assert(pubSpan.SpanKind == trace.SpanKindClient, "Expect to be client span, got %d", pubSpan.SpanKind)
 		verifier.Assert(pubSpan.Name == "PUBLISH", "Except server span name to be PUBLISH, got %s", pubSpan.Name)
 	}, 1)
+	verifier.WaitAndAssertMetrics(map[string]func(metricdata.ResourceMetrics){
+		"db.client.request.duration": func(mrs metricdata.ResourceMetrics) {
+			if len(mrs.ScopeMetrics) <= 0 {
+				panic("No db.client.request.duration metrics received!")
+			}
+			point := mrs.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[float64])
+			if len(point.DataPoints) <= 0 {
+				panic("db.client.request.duration has no datapoints")
+			}
+			found := false
+			for _, dp := range point.DataPoints {
+				if dp.Count <= 0 {
+					continue
+				}
+				attrs := dp.Attributes.ToSlice()
+				if verifier.GetAttribute(attrs, "db.system.name").AsString() == "rueidis" &&
+					verifier.GetAttribute(attrs, "db.operation.name").AsString() == "PING" &&
+					verifier.GetAttribute(attrs, "server.address").AsString() == redisAddr {
+					found = true
+					break
+				}
+			}
+			if !found {
+				panic("db.client.request.duration missing PING datapoint for rueidis")
+			}
+		},
+	})
 }

--- a/test/rueidis/v1.0.30/test_basic.go
+++ b/test/rueidis/v1.0.30/test_basic.go
@@ -201,7 +201,7 @@ func main() {
 					continue
 				}
 				attrs := dp.Attributes.ToSlice()
-				if verifier.GetAttribute(attrs, "db.system.name").AsString() == "rueidis" &&
+				if verifier.GetAttribute(attrs, "db.system.name").AsString() == "redis" &&
 					verifier.GetAttribute(attrs, "db.operation.name").AsString() == "PING" &&
 					verifier.GetAttribute(attrs, "server.address").AsString() == redisAddr {
 					found = true


### PR DESCRIPTION
## Summary

Several DB client instrumentations in loongsuite-go already emitted **traces** via `DbClientAttrsExtractor`, but never registered `db.DbClientMetrics`, so **`db.client.request.duration` was never recorded**. This PR closes that gap for ClickHouse, Cassandra (gocql), PostgreSQL (go-pg), rueidis, and Elasticsearch, and fixes Elasticsearch’s incorrect HTTP server metrics hook.

A defensive guard is added to `DbClientMetric.OnAfterEnd` so a mismatched Start/End context skips recording instead of panicking.

**Intentionally out of scope:** gorm and sqlx (see Notes).

## Motivation

- Align with OTel database client metrics semconv: failed/successful operations should contribute to `db.client.request.duration` with low-cardinality labels.
- Plugins such as mongo, goredis, redigo, and `database/sql` already call `AddOperationListeners(db.DbClientMetrics(...))`; ClickHouse and peers were inconsistent (trace-only).
- Elasticsearch previously wired `http.HttpServerMetrics` while using DB span attributes — the hook targeted the wrong metric instrument and did not match integration test expectations.

## Changes

### Instrumentation (5 plugins)

| Plugin | Listener key | Metric |
|--------|--------------|--------|
| clickhousev2 | `database.clickhouse` | `db.client.request.duration` |
| gocql | `nosql.gocql` | same |
| gopg | `database.gopg` | same |
| rueidisgo | `nosql.rueidis` | same |
| elasticsearch | `nosql.elasticsearch` | same (replaces `HttpServerMetrics`) |

Each change is a single line:

```go
AddOperationListeners(db.DbClientMetrics("<key>"))
```

### Shared metrics layer

- **`pkg/inst-api-semconv/instrumenter/db/db_metrics.go`**
  - `OnAfterEnd`: if metric context is missing or wrong type, **skip record** (no panic) and emit a debug log.
  - Switch `DbClientMetric` methods to **pointer receivers** so lazy-init of `clientRequestDuration` is persisted.
- **`pkg/inst-api-semconv/instrumenter/db/db_metrics_test.go`**
  - `TestDbClientMetricsMissingContext`: End without matching OnBeforeEnd must not panic.
  - `TestDbClientMetricsWrongTypeContext`: wrong-type context must not panic.

### Integration tests

Assert `db.client.request.duration` with attribute checks (not only histogram count):

| Test | Validates |
|------|-----------|
| clickhouse v2.13 / v2.42 | `db.system.name=clickhouse`, `db.operation.name=EXEC`, `server.address` |
| gocql v1.3 / v1.7 | `cassandra` + `SELECT` + host |
| gopg v10.10 / v10.14 | `postgresql` + `SELECT` + addr |
| rueidis v1.0.30 | `redis` + `PING` + redis addr |
| elasticsearch v8.4 / v8.5 metrics | `db.system.name=elasticsearch`; still asserts underlying `http.client.request.duration` |

## Changelog

### Added
- Export `db.client.request.duration` for ClickHouse, gocql, go-pg, rueidis, and Elasticsearch client instrumentations.
- Defensive handling in `DbClientMetric.OnAfterEnd` when Start/End context is not paired (skip record, no panic).
- Integration test assertions for DB metrics attributes on the plugins above.

### Fixed
- Elasticsearch: replace incorrect `HttpServerMetrics("elasticsearch.client")` with `DbClientMetrics("nosql.elasticsearch")` so ES operations emit DB client duration metrics consistent with DB span attributes.
- rueidis: align `db.system.name` to `redis` (OTel convention; matches goredis/redigo).

### Changed (telemetry / behavioral)
- **Elasticsearch no longer emits `http.server.request.duration` from the ES plugin.** See breaking-change note below.

### Unchanged / explicitly not included
- gorm and sqlx: remain trace-only in this PR (see Notes).
- Metric name remains `db.client.request.duration` (semconv rename to `db.client.operation.duration` is follow-up).
- `error.type` on DB metrics is not part of this PR (see #724 / #723).
- No dual-write deprecation shim for the removed ES `http.server.request.duration` (see rationale below).

## Breaking changes & operational impact

This is primarily an **observability additive change**, but it affects production telemetry:

| Impact | Detail |
|--------|--------|
| **New metric time series** | Services using the five plugins will start exporting `db.client.request.duration` where previously only traces existed. |
| **Cardinality** | Labels include `db.system.name`, `db.operation.name`, `server.address`, and `db.namespace` (when set). High-cardinality span attrs such as `db.query.text` are **not** exported on metrics. |
| **Elasticsearch dashboards** | ES plugin no longer emits `http.server.request.duration`; use `db.client.request.duration` instead. Transport-level **`http.client.request.duration`** from net/http may still appear — do not double-count. |
| **rueidis `db.system.name`** | Renamed from `"rueidis"` to `"redis"` (OTel semconv; aligns with goredis/redigo). Dashboards filtering `db.system.name="rueidis"` need updating. |
| **No Go API breaking change** | No public Go API changes. Full migration notes: `docs/user/compatibility.md` / `docs/zh/user/compatibility.md` (this PR). |

### rueidis: `db.system.name` `"rueidis"` → `"redis"`

Aligns with OTel semantic conventions (`db.system.name` identifies the database system, not the client library) and with goredis/redigo.

**Migration:** change dashboard/alert filters from `db.system.name="rueidis"` to `db.system.name="redis"`. Distinguish the client library via instrumentation scope name when needed.

### Elasticsearch: `http.server.request.duration` removal (intentional, no dual-write)

**Decision:** Replace the miswired listener only — **do not** dual-write `HttpServerMetrics` + `DbClientMetrics`.

**What changes for operators**

| Before (buggy) | After (this PR) |
|----------------|-----------------|
| ES plugin emitted `http.server.request.duration` on a **client** span with DB attributes | ES plugin emits `db.client.request.duration` with `db.system.name=elasticsearch` |
| Semconv mismatch: server metric name on client instrumentation | Aligns with other DB/NOSQL plugins (mongo, goredis, `database/sql`) |
| Integration tests never asserted `http.server.request.duration` for ES | Tests assert `db.client.request.duration` + `http.client.request.duration` (net/http transport) |

**What stays the same**

- `http.client.request.duration` from **net/http** transport instrumentation is unchanged.
- ES traces/span attributes are unchanged.

**Migration guide**

- For ES API / DB-semantics latency: use `db.client.request.duration` filtered by `db.system.name=elasticsearch`.
- For HTTP transport latency: use `http.client.request.duration`.
- If a dashboard filtered on ES scope + `http.server.request.duration`, update it — that series was semantically incorrect and is removed by design.

**Why not dual-write?** Dual-writing would preserve a wrong metric name (`http.server.*` on client calls), add duplicate/confusing series alongside `http.client.request.duration`, and increase maintenance cost. The prior hook was a bug fix target, not a supported contract.

**Recommendation for operators:** Review dashboards/alerts that aggregate DB latency; add filters on `db.system.name` / `db.operation.name` as needed. Expect increased metric export volume for newly instrumented plugins.

## Notes & design decisions

### Why gorm / sqlx are excluded

1. **Double counting with `database/sql`:** gorm and sqlx typically delegate to `database/sql`, which already records `db.client.request.duration` via `database.sql`. Enabling plugin-level metrics would approximate **2× request counts** on latency aggregates.
2. **sqlx context bug:** sqlx hooks discard the context returned from `Start()` and call `End(context.Background(), ...)`. With metrics enabled, `OnAfterEnd` would read a missing metric context. A shared-layer guard prevents panic, but metrics would be silently dropped until setup is fixed — better to omit sqlx metrics until a dedicated fix lands.

### Elasticsearch: two metric layers

- **DB layer (this PR):** `db.client.request.duration` with `db.system.name=elasticsearch`, operation derived from HTTP path/method.
- **HTTP layer (existing net/http):** `http.client.request.duration` for the same underlying request.

Both are expected; they answer different questions (ES API vs HTTP transport).

### Known attribute semantics

- rueidis: `db.system.name=redis` (aligned with goredis/redigo in this PR).
- Elasticsearch: `db.operation.name` follows HTTP path heuristics (e.g. `PUT /my_index` → `put`, not `indices.create`).
- Elasticsearch: `server.address` may be a full URL string from the client transport.

### Listener key naming

Internal context keys only (`database.clickhouse`, `nosql.gocql`, etc.); they do **not** appear as metric labels. Naming follows existing `database.*` / `nosql.*` convention in the repo.

## Test plan

- [x] `go test ./inst-api-semconv/instrumenter/db/ -race` (from `pkg/`)
- [x] `go test ./inst-api/instrumenter/ -race` (from `pkg/`)
- [x] Local: `rueidis-1.0.30-basic-test` integration test
- [ ] CI: `test_clickhousev2_crud` (v2.13, v2.42)
- [ ] CI: `test_gocql_crud` (v1.3, v1.7)
- [ ] CI: `test_gopg_crud` (v10.10, v10.14)
- [ ] CI: `test_es_metrics` / typed client metrics (v8.4, v8.5)

## Related work

- #723 / PR #724: `error.type` on DB client metrics (separate change; not included here).
