### PR TITLE
optimize(langchain): add nil-guard in callChainOnExit to match OnEnter

### DIFF
--- a/pkg/rules/langchain/chains_setup.go
+++ b/pkg/rules/langchain/chains_setup.go
@@ -54,7 +54,14 @@ func callChainOnExit(call api.CallContext, v map[string]any, err error) {
 	if !langChainEnabler.Enable() {
 		return
 	}
-	data := call.GetData().(map[string]interface{})
+	dataRaw := call.GetData()
+	if dataRaw == nil {
+		return
+	}
+	data, ok := dataRaw.(map[string]interface{})
+	if !ok {
+		return
+	}
 	ctx, ok := data["ctx"].(context.Context)
 	if !ok {
 		return


### PR DESCRIPTION
## Summary

- Fixed asymmetric panic-guard in `pkg/rules/langchain/chains_setup.go`: `callChainOnEnter` early-returns when `langChainEnabler.Enable()` is false (skipping `call.SetData`), but `callChainOnExit` then panicked on the unchecked `call.GetData().(map[string]interface{})` type assertion when `GetData()` returned nil.
- Applied the same nil-check + comma-ok pattern already used by `executorCallOnExit` (executor_setup.go:52-67) to keep the guard symmetric.
- Rule JSON (`tool/data/rules/langchaingo.json`) unchanged — linkname target and hook signature unchanged.

## Validation

- `go build ./pkg/rules/langchain/...` — OK
- `go vet ./pkg/rules/langchain/...` — OK
- `go test ./pkg/rules/langchain/...` — no test files in package
- `golangci-lint run ./pkg/rules/langchain/...` — chains_setup.go clean (14 pre-existing staticcheck warnings in `common_otel_instrumenter.go`, untouched)

Note: `make lint` at the repo root fails on a pre-existing `tool/otel/main.go` VCS status error (`error obtaining VCS status: exit status 128`), unrelated to this change.

## Notes

- Workspace `ARMS 探针研发` does not have `go-agent/otel-go-auto-instrumentation` configured for checkout (only `alibaba/loongsuite-go-agent`). Used the fallback repo per `code-optimizer-go` skill.
- Used personal fork `rangemer333-cell/langchain-fork-20260716` because the agent's GitHub identity has only READ permission on `alibaba/loongsuite-go-agent`.

Aone ID (per CLAUDE.md): 84291952