### PR TITLE
optimize(segmentio-kafka-go): bump kafka-go to v0.4.51 so rule module builds

### DIFF
--- a/pkg/rules/segmentio-kafka-go/go.mod
+++ b/pkg/rules/segmentio-kafka-go/go.mod
@@ -6,7 +6,7 @@ replace github.com/alibaba/loongsuite-go/pkg => ../../../pkg
 
 require (
 	github.com/alibaba/loongsuite-go/pkg v0.0.0-00010101000000-000000000000
-	github.com/segmentio/kafka-go v0.4.0
+	github.com/segmentio/kafka-go v0.4.51
 	go.opentelemetry.io/otel v1.40.0
 	go.opentelemetry.io/otel/sdk v1.40.0
 	go.opentelemetry.io/otel/trace v1.40.0
@@ -16,10 +16,9 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
-	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
+	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect


### PR DESCRIPTION
## Summary

The per-rule `go.mod` for `pkg/rules/segmentio-kafka-go/` pinned `github.com/segmentio/kafka-go v0.4.0`, but the producer hook reads `writer.Topic` / `writer.Addr` / `writer.Async`, which only exist as **direct public fields** on `Writer` in newer kafka-go versions (in v0.4.0 `Writer` only exposes an unexported `config WriterConfig`; `Topic`/`Addr`/`Async` live there and cannot be reached from outside the package).

Result: `go test ./pkg/rules/segmentio-kafka-go/...` failed at **build time** — the rule declares compatibility with `[0.4.0,)` in `tool/data/rules/kafka.json` but its hook code does not compile against v0.4.0.

## Fix

Bump the per-rule test-time dependency to `v0.4.51` (latest). This matches the pattern used by sibling kafka rules (`franz-go v1.18.0`, `ibm-sarama v1.40.0`) and lets Phase 4 validation actually run.

- No production hook code changed.
- `tool/data/rules/kafka.json` `Version` range unchanged.

## Validation

- `go test ./pkg/rules/segmentio-kafka-go/...` → pass (compiles cleanly, no test files)
- `go vet ./...` (in rule module) → clean
- `gofmt -l pkg/rules/segmentio-kafka-go/` → clean
- `GOFLAGS=-buildvcs=false make lint` → 0 issues

## Manual follow-ups (report-only, out of scope for this MR)

- `tool/data/rules/kafka.json` declares `Version: "[0.4.0,)"`. The hook code uses `Writer.Topic`/`Addr`/`Async`, which were promoted to direct fields on `Writer` only in newer kafka-go releases; users on early v0.4.x may hit a build failure in their own project. Narrowing the range requires coordinated toolchain validation, so it is left as a follow-up.

Aone ID: 84291952