### PR TITLE
fix: stop emitting false errors for SQLite in database/sql instrumentation

### DIFF
--- a/pkg/rules/databasesql/databasesql_extractor.go
+++ b/pkg/rules/databasesql/databasesql_extractor.go
@@ -16,14 +16,38 @@ package databasesql
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/xwb1989/sqlparser"
 )
 
+// isParsableDML reports whether the statement is one of the DML statements
+// that the metadata extraction below actually understands. Feeding anything
+// else (e.g. DDL) into the MySQL-oriented sqlparser is useless and can make
+// the parser itself emit misleading "ignoring error parsing DDL" logs for
+// dialect-specific syntax such as SQLite's AUTOINCREMENT.
+func isParsableDML(sql string) bool {
+	fields := strings.Fields(sql)
+	if len(fields) == 0 {
+		return false
+	}
+	switch strings.ToUpper(fields[0]) {
+	case "SELECT", "INSERT", "UPDATE", "DELETE":
+		return true
+	}
+	return false
+}
+
 func extractSQLMetadata(request databaseSqlRequest) {
 	sql := request.sql
 
-	if sqlCache.Contains(sql) {
+	if meta, found := sqlCache.Get(sql); found {
+		// The collection may have been cached by getCollection() already,
+		// complete the missing operation without parsing the SQL again.
+		if meta.operation == "" && request.opType != "" {
+			meta.operation = request.opType
+			sqlCache.Add(sql, meta)
+		}
 		return
 	}
 
@@ -41,8 +65,11 @@ func getCollection(sql string) string {
 	if meta, found := sqlCache.Get(sql); found {
 		return meta.collection
 	}
-	// Attempt to retrieve the collection again.
-	return extractCollection(sql)
+	// Cache the result so that the same statement will not be parsed again
+	// by the subsequent metadata extraction.
+	collection := extractCollection(sql)
+	sqlCache.Add(sql, SQLMeta{stmt: sql, collection: collection})
+	return collection
 }
 
 func getParams(sql string) []any {
@@ -67,11 +94,14 @@ func getParams(sql string) []any {
 }
 
 func extractCollection(query string) string {
+	// Only support DML currently
+	if !isParsableDML(query) {
+		return ""
+	}
 	stmt, err := sqlparser.Parse(query)
 	if err != nil {
 		return ""
 	}
-	// Only support DML currently
 	switch stmt := stmt.(type) {
 	case *sqlparser.Select:
 		return getTableName(stmt.From)
@@ -107,6 +137,10 @@ func getTableName(node sqlparser.SQLNode) string {
 
 // Extract SQL parameters
 func extractSQLParams(query string) (map[string]string, error) {
+	// Only support DML currently
+	if !isParsableDML(query) {
+		return nil, nil
+	}
 	stmt, err := sqlparser.Parse(query)
 	if err != nil {
 		log.Printf("failed to fetch sql params: %v", err)
@@ -114,7 +148,6 @@ func extractSQLParams(query string) (map[string]string, error) {
 	}
 
 	values := make(map[string]string)
-	// Only support DML currently
 	switch stmt := stmt.(type) {
 	case *sqlparser.Select:
 		if stmt.Where != nil {

--- a/pkg/rules/databasesql/databasesql_parser.go
+++ b/pkg/rules/databasesql/databasesql_parser.go
@@ -29,6 +29,11 @@ func parseDSN(driverName, dsn string) (addr string, err error) {
 		fallthrough
 	case "postgresql":
 		return parsePostgres(dsn)
+	case "sqlite", "sqlite3":
+		// SQLite is an embedded database whose DSN is a file path (or
+		// ":memory:") rather than a network address, so there is no
+		// endpoint to extract and nothing to report as an error.
+		return "", nil
 	}
 
 	return "", errors.New("invalid DSN")


### PR DESCRIPTION
## Description

Fixes #736

When a `database/sql` application using SQLite is built with `otel go build`, the `databasesql` instrumentation emits misleading error logs even though every database operation succeeds. This PR fixes the three problems reported in the issue:

### 1. `failed to parse dsn: invalid DSN` for SQLite driver names

`parseDSN` in `databasesql_parser.go` only recognized `mysql`/`postgres`/`postgresql`. It now also recognizes `sqlite` and `sqlite3` and returns an empty endpoint without an error, since SQLite is an embedded database whose DSN is a file path (or `:memory:`) with no network address. Unknown drivers still return an error as before.

### 2. `ignoring error parsing DDL ...` for SQLite `AUTOINCREMENT`

The `ignoring error parsing DDL` message is emitted internally by `github.com/xwb1989/sqlparser` (MySQL grammar) when it partially parses a DDL statement, so it cannot be suppressed from the outside. Since the metadata extraction in `databasesql_extractor.go` only understands `SELECT`/`INSERT`/`UPDATE`/`DELETE` anyway, a new `isParsableDML` pre-check now skips the parser entirely for non-DML statements (DDL, `PRAGMA`, etc.). This applies to both `extractCollection` and `extractSQLParams`.

### 3. The same statement was parsed twice

For a cache miss, `DBSpanNameExtractor.Extract` → `GetCollection` → `getCollection` parsed the statement first but did **not** cache the result, and then the attributes extractor (`GetStatement` → `extractSQLMetadata`) parsed the same statement again — which is also why the DDL warning above was printed twice. `getCollection` now caches the parsed collection on a miss, and `extractSQLMetadata` reuses the cached entry (only backfilling the missing operation) instead of re-parsing.

## Verification

- Reproduced the issue with the program from #736 (`mattn/go-sqlite3` + `CREATE TABLE ... AUTOINCREMENT`). After this fix, `otel go build` + run produces no `failed to parse dsn` and no `ignoring error parsing DDL` logs, while DML statements still yield the correct collection/span metadata.
- Unit-tested the pure logic (parseDSN for sqlite/sqlite3/mysql/postgres/unknown; DDL is skipped without any log output; DML still parsed; `getCollection` caches its result so the statement is parsed only once). The tests are not added under `pkg/rules/databasesql` because that package references fields injected at otel-build time and cannot be compiled standalone.
- Existing MySQL behavior is unchanged: only sqlite driver names short-circuit in `parseDSN`, and the DML pre-check accepts exactly the statement types the extractor already handled.
