### PR TITLE
fix(goredis): sanitize Redis command text to prevent invalid UTF-8 in OTLP spans

### DIFF
--- a/pkg/rules/goredis/goredis_otel_instrumenter.go
+++ b/pkg/rules/goredis/goredis_otel_instrumenter.go
@@ -17,6 +17,7 @@ package goredis
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/alibaba/loongsuite-go/pkg/inst-api-semconv/instrumenter/db"
 	"github.com/alibaba/loongsuite-go/pkg/inst-api/instrumenter"
@@ -106,7 +107,7 @@ func getRedisV9Statement(cmd redis.Cmder) string {
 		b = redisV9AppendArg(b, cmd)
 	}
 
-	return redisV9String(b)
+	return strings.ToValidUTF8(redisV9String(b), "\uFFFD")
 }
 
 func redisV9String(b []byte) string {
@@ -176,6 +177,10 @@ func redisV9AppendArg(b []byte, v interface{}) []byte {
 	case time.Time:
 		return v.AppendFormat(b, time.RFC3339Nano)
 	default:
-		return append(b, fmt.Sprint(v)...)
+		s := fmt.Sprint(v)
+		if !utf8.ValidString(s) {
+			s = strings.ToValidUTF8(s, "\uFFFD")
+		}
+		return append(b, s...)
 	}
 }


### PR DESCRIPTION
Fix #738 

## Summary

Fix OTLP trace export failures caused by invalid UTF-8 in the go-redis instrumentation.

When a Redis command carries binary arguments, the formatted `db.query.text` attribute can contain non-UTF-8 bytes. OTLP protobuf requires string fields to be valid UTF-8, so trace export fails with:

```text
traces export: string field contains invalid UTF-8
```

## Root cause
 The invalid UTF-8 bytes come from Redis commands that carry binary arguments.Redis is binary-safe, and passing arbitrary bytes as command arguments is valid usage.  It is caused by loongsuite-go's go-redis instrumentation formatting those binary bytes into the string attribute `db.query.text` without UTF-8 validation.

## Changes

- Sanitize the final `db.query.text` value with `strings.ToValidUTF8` before returning it.
- Sanitize the `default` branch of `redisV9AppendArg` so unknown `Stringer` values cannot inject invalid UTF-8 into the statement.