### PR TITLE
feat(aws-sdk-go): add instrumentation rule to prevent SigV4 signature corruption on retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The detailed usage of `otel` tool can be found in [**Usage**](./docs/user/config
 | ants               | https://github.com/panjf2000/ants               | v1.1.0      | -           |
 | anthropic-sdk-go   | https://github.com/anthropics/anthropic-sdk-go  | v1.25.0     | -           |
 | asynq              | https://github.com/hibiken/asynq                | v0.23.0     | v0.26.0     |
+| aws-sdk-go         | https://github.com/aws/aws-sdk-go               | v1.55.5     | -           |
 | clickhouse/v2      | https://github.com/ClickHouse/clickhouse-go/v2  | v2.13.0     | -           |
 | cron               | https://github.com/robfig/cron/v3               | v3.0.0      | -           |
 | database/sql       | https://pkg.go.dev/database/sql                 | -           | -           |

--- a/docs/user/supported-libraries.md
+++ b/docs/user/supported-libraries.md
@@ -6,6 +6,7 @@
 | amqp091            | https://github.com/rabbitmq/amqp091-go            | v1.10.0     | -           |
 | anthropic-sdk-go   | https://github.com/anthropics/anthropic-sdk-go    | v1.25.0     | -           |
 | asynq              | https://github.com/hibiken/asynq                  | v0.23.0     | v0.26.0     |
+| aws-sdk-go         | https://github.com/aws/aws-sdk-go                 | v1.55.5     | -           |
 | clickhouse/v2      | https://github.com/ClickHouse/clickhouse-go/v2    | v2.13.0     | -           |
 | database/sql       | https://pkg.go.dev/database/sql                   | -           | -           |
 | deepseek           | https://github.com/cohesion-org/deepseek-go       | v1.3.0      | -           |

--- a/docs/zh/user/supported-libraries.md
+++ b/docs/zh/user/supported-libraries.md
@@ -6,6 +6,7 @@
 | amqp091              | https://github.com/rabbitmq/amqp091-go                      | v1.10.0     | -           |
 | anthropic-sdk-go    | https://github.com/anthropics/anthropic-sdk-go              | v1.25.0     | -           |
 | asynq               | https://github.com/hibiken/asynq                            | v0.23.0     | v0.26.0     |
+| aws-sdk-go          | https://github.com/aws/aws-sdk-go                           | v1.55.5     | -           |
 | clickhouse/v2       | https://github.com/ClickHouse/clickhouse-go/v2              | v2.13.0     | -           |
 | database/sql        | https://pkg.go.dev/database/sql                             | -           | -           |
 | deepseek            | https://github.com/cohesion-org/deepseek-go                 | v1.3.0      | -           |

--- a/pkg/rules/aws-sdk-go/go.mod
+++ b/pkg/rules/aws-sdk-go/go.mod
@@ -1,0 +1,21 @@
+module github.com/alibaba/loongsuite-go/pkg/rules/aws-sdk-go
+
+go 1.24.0
+
+require (
+	github.com/alibaba/loongsuite-go/pkg v0.0.0-00010101000000-000000000000
+	github.com/aws/aws-sdk-go v1.55.5
+	go.opentelemetry.io/otel v1.40.0
+	go.opentelemetry.io/otel/trace v1.40.0
+)
+
+require (
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/otel/metric v1.40.0 // indirect
+)
+
+replace github.com/alibaba/loongsuite-go/pkg => ../../../pkg

--- a/pkg/rules/aws-sdk-go/go.mod
+++ b/pkg/rules/aws-sdk-go/go.mod
@@ -2,6 +2,8 @@ module github.com/alibaba/loongsuite-go/pkg/rules/aws-sdk-go
 
 go 1.24.0
 
+toolchain go1.24.13
+
 require (
 	github.com/alibaba/loongsuite-go/pkg v0.0.0-00010101000000-000000000000
 	github.com/aws/aws-sdk-go v1.55.5

--- a/pkg/rules/aws-sdk-go/setup.go
+++ b/pkg/rules/aws-sdk-go/setup.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws_sdk_go
+
+import (
+	_ "unsafe"
+
+	"github.com/alibaba/loongsuite-go/pkg/api"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+const tracerName = "github.com/aws/aws-sdk-go"
+
+// newSessionOnExit hooks session.NewSession's return value so we can attach
+// tracing handlers to every client created from the session.
+//
+//go:linkname newSessionOnExit github.com/aws/aws-sdk-go/aws/session.newSessionOnExit
+func newSessionOnExit(call api.CallContext, sess *session.Session, err error) {
+	if err != nil || sess == nil {
+		return
+	}
+	installTraceHandlers(&sess.Handlers)
+}
+
+// newSessionWithOptionsOnExit covers session.NewSessionWithOptions.
+//
+//go:linkname newSessionWithOptionsOnExit github.com/aws/aws-sdk-go/aws/session.newSessionWithOptionsOnExit
+func newSessionWithOptionsOnExit(call api.CallContext, sess *session.Session, err error) {
+	if err != nil || sess == nil {
+		return
+	}
+	installTraceHandlers(&sess.Handlers)
+}
+
+func installTraceHandlers(h *request.Handlers) {
+	// (1) Correctness fix: strip W3C trace context BEFORE SigV4 signing.
+	//
+	// The generic net/http instrumentation injects `traceparent` at
+	// Transport.RoundTrip time. On a retry (e.g. server 503 SlowDown),
+	// aws-sdk-go reuses the same *http.Request whose header still carries the
+	// previously injected traceparent; the re-sign then folds it into
+	// SignedHeaders, while RoundTrip overwrites the value again -> the signed
+	// value no longer matches the sent value -> 403 SignatureDoesNotMatch /
+	// AccessDenied. Removing it before signing keeps it out of SignedHeaders,
+	// so it can never corrupt the signature regardless of later injection.
+	h.Sign.PushFront(func(r *request.Request) {
+		if r.HTTPRequest == nil {
+			return
+		}
+		r.HTTPRequest.Header.Del("traceparent")
+		r.HTTPRequest.Header.Del("tracestate")
+	})
+
+	// (2) Observability: emit a client span per SDK operation via the SDK's
+	// own handler chain, so trace context is carried in-process (not through
+	// signed HTTP headers) and never affects signing.
+	h.Send.PushFront(func(r *request.Request) {
+		spanName := r.Operation.Name
+		if r.ClientInfo.ServiceName != "" {
+			spanName = r.ClientInfo.ServiceName + "." + r.Operation.Name
+		}
+		ctx, span := otel.Tracer(tracerName).Start(
+			r.Context(), spanName, oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		)
+		span.SetAttributes(
+			attribute.String("rpc.system", "aws-api"),
+			attribute.String("rpc.service", r.ClientInfo.ServiceName),
+			attribute.String("rpc.method", r.Operation.Name),
+		)
+		r.SetContext(ctx)
+	})
+	h.Complete.PushBack(func(r *request.Request) {
+		span := oteltrace.SpanFromContext(r.Context())
+		if !span.IsRecording() {
+			return
+		}
+		defer span.End()
+		if r.HTTPResponse != nil {
+			span.SetAttributes(attribute.Int("http.response.status_code", r.HTTPResponse.StatusCode))
+		}
+		if r.Error != nil {
+			span.SetStatus(codes.Error, r.Error.Error())
+		}
+	})
+}

--- a/pkg/rules/aws-sdk-go/setup.go
+++ b/pkg/rules/aws-sdk-go/setup.go
@@ -65,20 +65,31 @@ func newSessionWithOptionsOnExit(call api.CallContext, sess *session.Session, er
 }
 
 func installTraceHandlers(h *request.Handlers) {
-	// (1) Correctness fix: strip W3C trace context BEFORE SigV4 signing.
+	// (1) Correctness fix: strip W3C trace context before re-signing a retry.
 	//
 	// The generic net/http instrumentation injects `traceparent` at
-	// Transport.RoundTrip time. On a retry (e.g. server 503 SlowDown),
-	// aws-sdk-go reuses the same *http.Request whose header still carries the
-	// previously injected traceparent; the re-sign then folds it into
-	// SignedHeaders, while RoundTrip overwrites the value again -> the signed
-	// value no longer matches the sent value -> 403 SignatureDoesNotMatch /
-	// AccessDenied. Removing it before signing keeps it out of SignedHeaders,
-	// so it can never corrupt the signature regardless of later injection.
+	// Transport.RoundTrip time, i.e. after signing. The first attempt is
+	// therefore always safe: the header does not exist yet when SigV4 runs,
+	// so it never enters SignedHeaders. On a retry (e.g. server 503
+	// SlowDown), aws-sdk-go reuses the same *http.Request, whose header still
+	// carries the traceparent injected during the previous attempt; the
+	// re-sign folds it into SignedHeaders, while RoundTrip then overwrites
+	// the value with a new span -> the signed value no longer matches the
+	// sent value -> 403 SignatureDoesNotMatch / AccessDenied.
+	//
+	// Only retries are stripped, so trace context injected or set by the
+	// caller still propagates on the first attempt, and disabling the
+	// net/http instrumentation does not silently lose it.
+	//
+	// Residual window: a caller that sets `traceparent` on the request itself
+	// while the net/http instrumentation is enabled still gets the signed
+	// value overwritten on the very first attempt. Stripping unconditionally
+	// would close that too, at the cost of severing propagation for everyone
+	// else; the retry path is the one observed in practice.
 	h.Sign.SetFrontNamed(request.NamedHandler{
 		Name: stripTraceHeadersHandlerName,
 		Fn: func(r *request.Request) {
-			if r.HTTPRequest == nil {
+			if r.HTTPRequest == nil || r.RetryCount == 0 {
 				return
 			}
 
@@ -87,9 +98,17 @@ func installTraceHandlers(h *request.Handlers) {
 		},
 	})
 
-	// (2) Observability: emit a client span per SDK operation via the SDK's
-	// own handler chain, so trace context is carried in-process (not through
+	// (2) Observability: emit a span per SDK operation via the SDK's own
+	// handler chain, so trace context is carried in-process (not through
 	// signed HTTP headers) and never affects signing.
+	//
+	// The span is Internal, not Client: aws-sdk-go issues its requests
+	// through net/http, which the generic instrumentation already covers with
+	// its own client span. That span is not suppressed here (SpanKeySuppressor
+	// matches on scope names registered in InstrumentationRegistry, which this
+	// rule is not), so a Client span would double-count every outbound AWS
+	// call. Sibling SDK rules that sit on top of net/http (anthropic-sdk-go,
+	// deepseek) make the same choice.
 	//
 	// Send runs once per attempt while Complete runs once per request, so the
 	// span is created on the first attempt only and reused across retries;
@@ -101,19 +120,33 @@ func installTraceHandlers(h *request.Handlers) {
 				return
 			}
 
-			spanName := r.Operation.Name
-			if r.ClientInfo.ServiceName != "" {
-				spanName = r.ClientInfo.ServiceName + "." + r.Operation.Name
+			// Standard SDK clients always set Operation, but these handlers
+			// are attached to every request from the session, including
+			// hand-built ones.
+			operation := ""
+			if r.Operation != nil {
+				operation = r.Operation.Name
+			}
+
+			spanName := operation
+			if spanName == "" {
+				spanName = tracerName
+			} else if r.ClientInfo.ServiceName != "" {
+				spanName = r.ClientInfo.ServiceName + "." + operation
 			}
 
 			ctx, span := otel.Tracer(tracerName).Start(
-				r.Context(), spanName, oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+				r.Context(), spanName, oteltrace.WithSpanKind(oteltrace.SpanKindInternal),
 			)
 			span.SetAttributes(
 				attribute.String("rpc.system", "aws-api"),
 				attribute.String("rpc.service", r.ClientInfo.ServiceName),
-				attribute.String("rpc.method", r.Operation.Name),
+				attribute.String("rpc.method", operation),
 			)
+
+			if r.HTTPRequest != nil && r.HTTPRequest.URL != nil {
+				span.SetAttributes(attribute.String("server.address", r.HTTPRequest.URL.Host))
+			}
 
 			r.SetContext(context.WithValue(ctx, spanContextKey{}, span))
 		},

--- a/pkg/rules/aws-sdk-go/setup.go
+++ b/pkg/rules/aws-sdk-go/setup.go
@@ -15,6 +15,7 @@
 package aws_sdk_go
 
 import (
+	"context"
 	_ "unsafe"
 
 	"github.com/alibaba/loongsuite-go/pkg/api"
@@ -27,6 +28,20 @@ import (
 )
 
 const tracerName = "github.com/aws/aws-sdk-go"
+
+// Handler names, so the handlers are installed by name (replace-if-present)
+// and re-running the rule cannot stack duplicates onto the same list.
+const (
+	stripTraceHeadersHandlerName = "loongsuite-go/aws-sdk-go.StripTraceHeaders"
+	startSpanHandlerName         = "loongsuite-go/aws-sdk-go.StartSpan"
+	endSpanHandlerName           = "loongsuite-go/aws-sdk-go.EndSpan"
+)
+
+// spanContextKey carries the span started by this rule on the request
+// context. Looking it up with trace.SpanFromContext instead would return the
+// caller's parent span whenever this rule never started one (e.g. the request
+// failed during Validate/Build/Sign, so Send never ran) and end it early.
+type spanContextKey struct{}
 
 // newSessionOnExit hooks session.NewSession's return value so we can attach
 // tracing handlers to every client created from the session.
@@ -60,43 +75,69 @@ func installTraceHandlers(h *request.Handlers) {
 	// value no longer matches the sent value -> 403 SignatureDoesNotMatch /
 	// AccessDenied. Removing it before signing keeps it out of SignedHeaders,
 	// so it can never corrupt the signature regardless of later injection.
-	h.Sign.PushFront(func(r *request.Request) {
-		if r.HTTPRequest == nil {
-			return
-		}
-		r.HTTPRequest.Header.Del("traceparent")
-		r.HTTPRequest.Header.Del("tracestate")
+	h.Sign.SetFrontNamed(request.NamedHandler{
+		Name: stripTraceHeadersHandlerName,
+		Fn: func(r *request.Request) {
+			if r.HTTPRequest == nil {
+				return
+			}
+
+			r.HTTPRequest.Header.Del("traceparent")
+			r.HTTPRequest.Header.Del("tracestate")
+		},
 	})
 
 	// (2) Observability: emit a client span per SDK operation via the SDK's
 	// own handler chain, so trace context is carried in-process (not through
 	// signed HTTP headers) and never affects signing.
-	h.Send.PushFront(func(r *request.Request) {
-		spanName := r.Operation.Name
-		if r.ClientInfo.ServiceName != "" {
-			spanName = r.ClientInfo.ServiceName + "." + r.Operation.Name
-		}
-		ctx, span := otel.Tracer(tracerName).Start(
-			r.Context(), spanName, oteltrace.WithSpanKind(oteltrace.SpanKindClient),
-		)
-		span.SetAttributes(
-			attribute.String("rpc.system", "aws-api"),
-			attribute.String("rpc.service", r.ClientInfo.ServiceName),
-			attribute.String("rpc.method", r.Operation.Name),
-		)
-		r.SetContext(ctx)
+	//
+	// Send runs once per attempt while Complete runs once per request, so the
+	// span is created on the first attempt only and reused across retries;
+	// otherwise every retry would start a nested span that is never ended.
+	h.Send.SetFrontNamed(request.NamedHandler{
+		Name: startSpanHandlerName,
+		Fn: func(r *request.Request) {
+			if _, ok := r.Context().Value(spanContextKey{}).(oteltrace.Span); ok {
+				return
+			}
+
+			spanName := r.Operation.Name
+			if r.ClientInfo.ServiceName != "" {
+				spanName = r.ClientInfo.ServiceName + "." + r.Operation.Name
+			}
+
+			ctx, span := otel.Tracer(tracerName).Start(
+				r.Context(), spanName, oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+			)
+			span.SetAttributes(
+				attribute.String("rpc.system", "aws-api"),
+				attribute.String("rpc.service", r.ClientInfo.ServiceName),
+				attribute.String("rpc.method", r.Operation.Name),
+			)
+
+			r.SetContext(context.WithValue(ctx, spanContextKey{}, span))
+		},
 	})
-	h.Complete.PushBack(func(r *request.Request) {
-		span := oteltrace.SpanFromContext(r.Context())
-		if !span.IsRecording() {
-			return
-		}
-		defer span.End()
-		if r.HTTPResponse != nil {
-			span.SetAttributes(attribute.Int("http.response.status_code", r.HTTPResponse.StatusCode))
-		}
-		if r.Error != nil {
-			span.SetStatus(codes.Error, r.Error.Error())
-		}
+
+	h.Complete.SetBackNamed(request.NamedHandler{
+		Name: endSpanHandlerName,
+		Fn: func(r *request.Request) {
+			// Only end the span this rule started; a request that failed
+			// before Send never stored one.
+			span, ok := r.Context().Value(spanContextKey{}).(oteltrace.Span)
+			if !ok || span == nil {
+				return
+			}
+
+			defer span.End()
+
+			if r.HTTPResponse != nil {
+				span.SetAttributes(attribute.Int("http.response.status_code", r.HTTPResponse.StatusCode))
+			}
+
+			if r.Error != nil {
+				span.SetStatus(codes.Error, r.Error.Error())
+			}
+		},
 	})
 }

--- a/pkg/rules/aws-sdk-go/setup.go
+++ b/pkg/rules/aws-sdk-go/setup.go
@@ -29,6 +29,9 @@ import (
 
 const tracerName = "github.com/aws/aws-sdk-go"
 
+// Span name for a request that carries no Operation to name it after.
+const defaultSpanName = "aws-sdk-go"
+
 // Handler names, so the handlers are installed by name (replace-if-present)
 // and re-running the rule cannot stack duplicates onto the same list.
 const (
@@ -130,7 +133,7 @@ func installTraceHandlers(h *request.Handlers) {
 
 			spanName := operation
 			if spanName == "" {
-				spanName = tracerName
+				spanName = defaultSpanName
 			} else if r.ClientInfo.ServiceName != "" {
 				spanName = r.ClientInfo.ServiceName + "." + operation
 			}

--- a/pkg/rules/aws-sdk-go/setup.go
+++ b/pkg/rules/aws-sdk-go/setup.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"net"
-	"net/url"
 	"reflect"
 	_ "unsafe"
 
@@ -170,8 +169,10 @@ func installTraceHandlers(h *request.Handlers) {
 			)
 
 			if r.HTTPRequest != nil && r.HTTPRequest.URL != nil {
-				host, port := splitHostPort(r.HTTPRequest.URL)
-				span.SetAttributes(attribute.String("server.address", host))
+				host, port := splitHostPort(r.HTTPRequest.URL.Host)
+				if host != "" {
+					span.SetAttributes(attribute.String("server.address", host))
+				}
 				if port != "" {
 					span.SetAttributes(attribute.String("server.port", port))
 				}
@@ -193,7 +194,11 @@ func installTraceHandlers(h *request.Handlers) {
 
 			defer span.End()
 
-			if r.HTTPResponse != nil {
+			// Send() substitutes an empty *http.Response before running
+			// Complete, so a request that never reached a server arrives here
+			// with a non-nil response whose StatusCode is 0. Reporting that as
+			// a status code is worse than omitting the attribute.
+			if r.HTTPResponse != nil && r.HTTPResponse.StatusCode != 0 {
 				span.SetAttributes(attribute.Int("http.response.status_code", r.HTTPResponse.StatusCode))
 			}
 
@@ -228,10 +233,10 @@ func serviceName(r *request.Request) string {
 // conventions keep apart. URL.Host carries the port only for non-default
 // endpoints (custom endpoints, MinIO, localstack), so the port is usually
 // absent and reported as such.
-func splitHostPort(u *url.URL) (string, string) {
-	host, port, err := net.SplitHostPort(u.Host)
+func splitHostPort(hostport string) (string, string) {
+	host, port, err := net.SplitHostPort(hostport)
 	if err != nil {
-		return u.Host, ""
+		return hostport, ""
 	}
 
 	return host, port

--- a/pkg/rules/aws-sdk-go/setup.go
+++ b/pkg/rules/aws-sdk-go/setup.go
@@ -16,9 +16,14 @@ package aws_sdk_go
 
 import (
 	"context"
+	"errors"
+	"net"
+	"net/url"
+	"reflect"
 	_ "unsafe"
 
 	"github.com/alibaba/loongsuite-go/pkg/api"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"go.opentelemetry.io/otel"
@@ -33,7 +38,10 @@ const tracerName = "github.com/aws/aws-sdk-go"
 const defaultSpanName = "aws-sdk-go"
 
 // Handler names, so the handlers are installed by name (replace-if-present)
-// and re-running the rule cannot stack duplicates onto the same list.
+// rather than appended. NewSession delegates to NewSessionWithOptions, so both
+// hooks fire for a single NewSession call and every session is installed onto
+// twice; naming the handlers keeps that idempotent instead of stacking
+// duplicates onto the same list.
 const (
 	stripTraceHeadersHandlerName = "loongsuite-go/aws-sdk-go.StripTraceHeaders"
 	startSpanHandlerName         = "loongsuite-go/aws-sdk-go.StartSpan"
@@ -84,11 +92,23 @@ func installTraceHandlers(h *request.Handlers) {
 	// caller still propagates on the first attempt, and disabling the
 	// net/http instrumentation does not silently lose it.
 	//
-	// Residual window: a caller that sets `traceparent` on the request itself
-	// while the net/http instrumentation is enabled still gets the signed
-	// value overwritten on the very first attempt. Stripping unconditionally
-	// would close that too, at the cost of severing propagation for everyone
-	// else; the retry path is the one observed in practice.
+	// What makes a header dangerous here is that its value changes between
+	// being signed and being sent. traceparent does: the net/http rule starts
+	// a fresh client span per attempt, so the span id differs every time.
+	// `baggage`, also injected by the default propagator, does not: it is
+	// derived from the context rather than from the per-attempt span, so the
+	// signed and sent values still match and it is left alone. Any future
+	// header that varies per attempt has to be added here.
+	//
+	// Two residual windows, both narrower than the one this closes:
+	//   - A caller that sets `traceparent` on the request itself while the
+	//     net/http instrumentation is enabled still gets the signed value
+	//     overwritten on the very first attempt.
+	//   - Conversely, with the net/http instrumentation disabled, a caller
+	//     that sets `traceparent` itself loses it from the retry onwards,
+	//     because nothing re-injects after the strip.
+	// Stripping unconditionally would close the first at the cost of widening
+	// the second for everyone; the retry path is the one observed in practice.
 	h.Sign.SetFrontNamed(request.NamedHandler{
 		Name: stripTraceHeadersHandlerName,
 		Fn: func(r *request.Request) {
@@ -131,11 +151,13 @@ func installTraceHandlers(h *request.Handlers) {
 				operation = r.Operation.Name
 			}
 
+			service := serviceName(r)
+
 			spanName := operation
 			if spanName == "" {
 				spanName = defaultSpanName
-			} else if r.ClientInfo.ServiceName != "" {
-				spanName = r.ClientInfo.ServiceName + "." + operation
+			} else if service != "" {
+				spanName = service + "." + operation
 			}
 
 			ctx, span := otel.Tracer(tracerName).Start(
@@ -143,12 +165,16 @@ func installTraceHandlers(h *request.Handlers) {
 			)
 			span.SetAttributes(
 				attribute.String("rpc.system", "aws-api"),
-				attribute.String("rpc.service", r.ClientInfo.ServiceName),
+				attribute.String("rpc.service", service),
 				attribute.String("rpc.method", operation),
 			)
 
 			if r.HTTPRequest != nil && r.HTTPRequest.URL != nil {
-				span.SetAttributes(attribute.String("server.address", r.HTTPRequest.URL.Host))
+				host, port := splitHostPort(r.HTTPRequest.URL)
+				span.SetAttributes(attribute.String("server.address", host))
+				if port != "" {
+					span.SetAttributes(attribute.String("server.port", port))
+				}
 			}
 
 			r.SetContext(context.WithValue(ctx, spanContextKey{}, span))
@@ -171,9 +197,54 @@ func installTraceHandlers(h *request.Handlers) {
 				span.SetAttributes(attribute.Int("http.response.status_code", r.HTTPResponse.StatusCode))
 			}
 
+			// Populated by the protocol's UnmarshalMeta handler, which runs
+			// before Complete. It is the identifier AWS support asks for, so
+			// it is worth carrying even on success.
+			if r.RequestID != "" {
+				span.SetAttributes(attribute.String("aws.request_id", r.RequestID))
+			}
+
 			if r.Error != nil {
+				span.SetAttributes(attribute.String("error.type", errorType(r.Error)))
+				span.RecordError(r.Error)
 				span.SetStatus(codes.Error, r.Error.Error())
 			}
 		},
 	})
+}
+
+// serviceName prefers ServiceID ("S3"), the identifier the OTel AWS semantic
+// conventions use for rpc.service, and falls back to ServiceName ("s3") for
+// clients built without one.
+func serviceName(r *request.Request) string {
+	if r.ClientInfo.ServiceID != "" {
+		return r.ClientInfo.ServiceID
+	}
+
+	return r.ClientInfo.ServiceName
+}
+
+// splitHostPort separates server.address from server.port, which the semantic
+// conventions keep apart. URL.Host carries the port only for non-default
+// endpoints (custom endpoints, MinIO, localstack), so the port is usually
+// absent and reported as such.
+func splitHostPort(u *url.URL) (string, string) {
+	host, port, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		return u.Host, ""
+	}
+
+	return host, port
+}
+
+// errorType reports the class of a failed request. AWS error codes
+// ("SlowDown", "AccessDenied") are the meaningful classification here; other
+// failures fall back to the concrete Go type.
+func errorType(err error) string {
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) {
+		return awsErr.Code()
+	}
+
+	return reflect.TypeOf(err).String()
 }

--- a/test/aws-sdk-go/v1.55.5/go.mod
+++ b/test/aws-sdk-go/v1.55.5/go.mod
@@ -1,0 +1,35 @@
+module test
+
+go 1.24.0
+
+replace github.com/alibaba/loongsuite-go => ../../../
+
+require (
+	github.com/alibaba/loongsuite-go/test/verifier v0.0.0
+	github.com/aws/aws-sdk-go v1.55.5
+	go.opentelemetry.io/otel/sdk v1.40.0
+	go.opentelemetry.io/otel/trace v1.40.0
+)
+
+require (
+	github.com/alibaba/loongsuite-go/pkg v0.0.0-00010101000000-000000000000 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/otel v1.40.0 // indirect
+	go.opentelemetry.io/otel/metric v1.40.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.40.0 // indirect
+	golang.org/x/sys v0.40.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+replace github.com/alibaba/loongsuite-go/test/verifier => ../../verifier
+
+replace github.com/alibaba/loongsuite-go/pkg => ../../../pkg

--- a/test/aws-sdk-go/v1.55.5/test_s3_retry.go
+++ b/test/aws-sdk-go/v1.55.5/test_s3_retry.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
@@ -78,18 +79,13 @@ func spansByName(stubs []tracetest.SpanStubs) map[string]tracetest.SpanStub {
 				continue
 			}
 
-			verifier.Assert(spansByNameIsUnique(spans, span.Name), "Expected exactly 1 %s span", span.Name)
+			_, seen := spans[span.Name]
+			verifier.Assert(!seen, "Expected exactly 1 %s span", span.Name)
 			spans[span.Name] = span
 		}
 	}
 
 	return spans
-}
-
-func spansByNameIsUnique(spans map[string]tracetest.SpanStub, name string) bool {
-	_, seen := spans[name]
-
-	return !seen
 }
 
 func main() {
@@ -146,12 +142,23 @@ func main() {
 	})
 	verifier.Assert(err != nil, "Expected GetObject to fail with AccessDenied")
 
+	// A third endpoint that is closed before use, so the request never gets
+	// an HTTP response at all and the span has no status code to report.
+	unreachable := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	unreachableURL := unreachable.URL
+	unreachable.Close()
+
+	_, err = s3.New(newSession(unreachableURL)).HeadBucketWithContext(context.Background(), &s3.HeadBucketInput{
+		Bucket: aws.String("test-bucket"),
+	})
+	verifier.Assert(err != nil, "Expected HeadBucket to fail against a closed endpoint")
+
 	verifier.WaitAndAssertTraces(func(stubs []tracetest.SpanStubs) {
 		spans := spansByName(stubs)
 
 		// One span per operation, reused across attempts: starting a span per
 		// attempt would leak every span but the last.
-		verifier.Assert(len(spans) == 2, "Expected exactly 2 aws-sdk-go spans, got %d", len(spans))
+		verifier.Assert(len(spans) == 3, "Expected exactly 3 aws-sdk-go spans, got %d", len(spans))
 
 		// rpc.service is ServiceID ("S3"), the identifier the OTel AWS
 		// semantic conventions use, not ServiceName ("s3").
@@ -194,5 +201,16 @@ func main() {
 
 		deniedID := verifier.GetAttribute(get.Attributes, "aws.request_id").AsString()
 		verifier.Assert(deniedID == deniedRequestID, "Expected aws.request_id to be %s, got %s", deniedRequestID, deniedID)
-	}, 2)
+
+		head, ok := spans["S3.HeadBucket"]
+		verifier.Assert(ok, "Expected a S3.HeadBucket span")
+
+		// No response ever arrived, so the attribute must be absent rather
+		// than reported as 0.
+		verifier.Assert(verifier.GetAttribute(head.Attributes, "http.response.status_code").Type() == attribute.INVALID,
+			"Expected http.response.status_code to be absent, got %v", verifier.GetAttribute(head.Attributes, "http.response.status_code"))
+
+		headErrorType := verifier.GetAttribute(head.Attributes, "error.type").AsString()
+		verifier.Assert(headErrorType == "RequestError", "Expected error.type to be RequestError, got %s", headErrorType)
+	}, 3)
 }

--- a/test/aws-sdk-go/v1.55.5/test_s3_retry.go
+++ b/test/aws-sdk-go/v1.55.5/test_s3_retry.go
@@ -27,11 +27,17 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 )
 
 const awsScopeName = "github.com/aws/aws-sdk-go"
+
+const (
+	retryRequestID  = "REQUESTID0000001"
+	deniedRequestID = "REQUESTID0000002"
+)
 
 // signedHeaders pulls the SignedHeaders list out of a SigV4 Authorization
 // header, i.e. the headers whose values the signature commits to.
@@ -46,14 +52,56 @@ func signedHeaders(authorization string) string {
 	return ""
 }
 
+func newSession(endpoint string) *session.Session {
+	sess, err := session.NewSession(&aws.Config{
+		Endpoint:         aws.String(endpoint),
+		Region:           aws.String("cn-north-1"),
+		Credentials:      credentials.NewStaticCredentials("test-ak", "test-sk", ""),
+		S3ForcePathStyle: aws.Bool(true),
+		DisableSSL:       aws.Bool(true),
+		MaxRetries:       aws.Int(3),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return sess
+}
+
+// spansByName groups the spans this rule emitted, across every trace, by span
+// name. Each operation is its own root, so they do not share a trace.
+func spansByName(stubs []tracetest.SpanStubs) map[string]tracetest.SpanStub {
+	spans := make(map[string]tracetest.SpanStub)
+	for _, t := range stubs {
+		for _, span := range t {
+			if span.InstrumentationScope.Name != awsScopeName {
+				continue
+			}
+
+			verifier.Assert(spansByNameIsUnique(spans, span.Name), "Expected exactly 1 %s span", span.Name)
+			spans[span.Name] = span
+		}
+	}
+
+	return spans
+}
+
+func spansByNameIsUnique(spans map[string]tracetest.SpanStub, name string) bool {
+	_, seen := spans[name]
+
+	return !seen
+}
+
 func main() {
 	var attempts int32
 
 	// Reproduces the production failure: the first attempt is throttled, and
 	// on the retry the server rejects the request if traceparent made it into
-	// SignedHeaders — the signed value is the one injected during the previous
+	// SignedHeaders - the signed value is the one injected during the previous
 	// attempt, while RoundTrip overwrites it with a fresh span before sending.
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	retryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Amz-Request-Id", retryRequestID)
+
 		if atomic.AddInt32(&attempts, 1) == 1 {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><Error><Code>SlowDown</Code><Message>Please reduce your request rate.</Message></Error>`))
@@ -70,21 +118,18 @@ func main() {
 
 		w.WriteHeader(http.StatusOK)
 	}))
-	defer mockServer.Close()
+	defer retryServer.Close()
 
-	sess, err := session.NewSession(&aws.Config{
-		Endpoint:         aws.String(mockServer.URL),
-		Region:           aws.String("cn-north-1"),
-		Credentials:      credentials.NewStaticCredentials("test-ak", "test-sk", ""),
-		S3ForcePathStyle: aws.Bool(true),
-		DisableSSL:       aws.Bool(true),
-		MaxRetries:       aws.Int(3),
-	})
-	if err != nil {
-		panic(err)
-	}
+	// A second, always-failing endpoint, so the error attributes are covered
+	// too. AccessDenied is not retryable, so this is a single attempt.
+	deniedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Amz-Request-Id", deniedRequestID)
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>`))
+	}))
+	defer deniedServer.Close()
 
-	_, err = s3.New(sess).PutObjectWithContext(context.Background(), &s3.PutObjectInput{
+	_, err := s3.New(newSession(retryServer.URL)).PutObjectWithContext(context.Background(), &s3.PutObjectInput{
 		Bucket: aws.String("test-bucket"),
 		Key:    aws.String("request_log/test-object"),
 		Body:   bytes.NewReader([]byte("hello")),
@@ -95,36 +140,59 @@ func main() {
 
 	verifier.Assert(atomic.LoadInt32(&attempts) == 2, "Expected the request to be retried once, got %d attempts", atomic.LoadInt32(&attempts))
 
+	_, err = s3.New(newSession(deniedServer.URL)).GetObjectWithContext(context.Background(), &s3.GetObjectInput{
+		Bucket: aws.String("test-bucket"),
+		Key:    aws.String("request_log/test-object"),
+	})
+	verifier.Assert(err != nil, "Expected GetObject to fail with AccessDenied")
+
 	verifier.WaitAndAssertTraces(func(stubs []tracetest.SpanStubs) {
-		var awsSpans []tracetest.SpanStub
+		spans := spansByName(stubs)
 
-		for _, t := range stubs {
-			for _, span := range t {
-				if span.InstrumentationScope.Name == awsScopeName {
-					awsSpans = append(awsSpans, span)
-				}
-			}
-		}
+		// One span per operation, reused across attempts: starting a span per
+		// attempt would leak every span but the last.
+		verifier.Assert(len(spans) == 2, "Expected exactly 2 aws-sdk-go spans, got %d", len(spans))
 
-		// One span for the operation, reused across attempts: starting a span
-		// per attempt would leak every span but the last.
-		verifier.Assert(len(awsSpans) == 1, "Expected exactly 1 aws-sdk-go span, got %d", len(awsSpans))
-
-		span := awsSpans[0]
-		verifier.Assert(span.Name == "s3.PutObject", "Expected span name to be s3.PutObject, got %s", span.Name)
+		// rpc.service is ServiceID ("S3"), the identifier the OTel AWS
+		// semantic conventions use, not ServiceName ("s3").
+		put, ok := spans["S3.PutObject"]
+		verifier.Assert(ok, "Expected a S3.PutObject span")
 
 		// Internal, so it does not double-count the net/http client span.
-		verifier.Assert(span.SpanKind == trace.SpanKindInternal, "Expected span kind to be internal, got %v", span.SpanKind)
+		verifier.Assert(put.SpanKind == trace.SpanKindInternal, "Expected span kind to be internal, got %v", put.SpanKind)
 
-		system := verifier.GetAttribute(span.Attributes, "rpc.system").AsString()
+		system := verifier.GetAttribute(put.Attributes, "rpc.system").AsString()
 		verifier.Assert(system == "aws-api", "Expected rpc.system to be aws-api, got %s", system)
 
-		service := verifier.GetAttribute(span.Attributes, "rpc.service").AsString()
-		verifier.Assert(service == "s3", "Expected rpc.service to be s3, got %s", service)
+		service := verifier.GetAttribute(put.Attributes, "rpc.service").AsString()
+		verifier.Assert(service == "S3", "Expected rpc.service to be S3, got %s", service)
 
-		method := verifier.GetAttribute(span.Attributes, "rpc.method").AsString()
+		method := verifier.GetAttribute(put.Attributes, "rpc.method").AsString()
 		verifier.Assert(method == "PutObject", "Expected rpc.method to be PutObject, got %s", method)
 
-		verifier.Assert(verifier.GetAttribute(span.Attributes, "server.address").AsString() != "", "Expected server.address to be set")
-	}, 1)
+		// server.address carries the host alone; the port of the test
+		// endpoint belongs in server.port.
+		address := verifier.GetAttribute(put.Attributes, "server.address").AsString()
+		verifier.Assert(address == "127.0.0.1", "Expected server.address to be 127.0.0.1, got %s", address)
+
+		port := verifier.GetAttribute(put.Attributes, "server.port").AsString()
+		verifier.Assert(port != "", "Expected server.port to be set")
+
+		status := verifier.GetAttribute(put.Attributes, "http.response.status_code").AsInt64()
+		verifier.Assert(status == 200, "Expected http.response.status_code to be 200, got %d", status)
+
+		requestID := verifier.GetAttribute(put.Attributes, "aws.request_id").AsString()
+		verifier.Assert(requestID == retryRequestID, "Expected aws.request_id to be %s, got %s", retryRequestID, requestID)
+
+		get, ok := spans["S3.GetObject"]
+		verifier.Assert(ok, "Expected a S3.GetObject span")
+
+		errorType := verifier.GetAttribute(get.Attributes, "error.type").AsString()
+		verifier.Assert(errorType == "AccessDenied", "Expected error.type to be AccessDenied, got %s", errorType)
+
+		verifier.Assert(get.Status.Code == codes.Error, "Expected the failed span status to be Error, got %v", get.Status.Code)
+
+		deniedID := verifier.GetAttribute(get.Attributes, "aws.request_id").AsString()
+		verifier.Assert(deniedID == deniedRequestID, "Expected aws.request_id to be %s, got %s", deniedRequestID, deniedID)
+	}, 2)
 }

--- a/test/aws-sdk-go/v1.55.5/test_s3_retry.go
+++ b/test/aws-sdk-go/v1.55.5/test_s3_retry.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+
+	"github.com/alibaba/loongsuite-go/test/verifier"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const awsScopeName = "github.com/aws/aws-sdk-go"
+
+// signedHeaders pulls the SignedHeaders list out of a SigV4 Authorization
+// header, i.e. the headers whose values the signature commits to.
+func signedHeaders(authorization string) string {
+	for _, part := range strings.Split(authorization, ",") {
+		part = strings.TrimSpace(part)
+		if after, ok := strings.CutPrefix(part, "SignedHeaders="); ok {
+			return after
+		}
+	}
+
+	return ""
+}
+
+func main() {
+	var attempts int32
+
+	// Reproduces the production failure: the first attempt is throttled, and
+	// on the retry the server rejects the request if traceparent made it into
+	// SignedHeaders — the signed value is the one injected during the previous
+	// attempt, while RoundTrip overwrites it with a fresh span before sending.
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&attempts, 1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><Error><Code>SlowDown</Code><Message>Please reduce your request rate.</Message></Error>`))
+
+			return
+		}
+
+		if strings.Contains(signedHeaders(r.Header.Get("Authorization")), "traceparent") {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>`))
+
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockServer.Close()
+
+	sess, err := session.NewSession(&aws.Config{
+		Endpoint:         aws.String(mockServer.URL),
+		Region:           aws.String("cn-north-1"),
+		Credentials:      credentials.NewStaticCredentials("test-ak", "test-sk", ""),
+		S3ForcePathStyle: aws.Bool(true),
+		DisableSSL:       aws.Bool(true),
+		MaxRetries:       aws.Int(3),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = s3.New(sess).PutObjectWithContext(context.Background(), &s3.PutObjectInput{
+		Bucket: aws.String("test-bucket"),
+		Key:    aws.String("request_log/test-object"),
+		Body:   bytes.NewReader([]byte("hello")),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	verifier.Assert(atomic.LoadInt32(&attempts) == 2, "Expected the request to be retried once, got %d attempts", atomic.LoadInt32(&attempts))
+
+	verifier.WaitAndAssertTraces(func(stubs []tracetest.SpanStubs) {
+		var awsSpans []tracetest.SpanStub
+
+		for _, t := range stubs {
+			for _, span := range t {
+				if span.InstrumentationScope.Name == awsScopeName {
+					awsSpans = append(awsSpans, span)
+				}
+			}
+		}
+
+		// One span for the operation, reused across attempts: starting a span
+		// per attempt would leak every span but the last.
+		verifier.Assert(len(awsSpans) == 1, "Expected exactly 1 aws-sdk-go span, got %d", len(awsSpans))
+
+		span := awsSpans[0]
+		verifier.Assert(span.Name == "s3.PutObject", "Expected span name to be s3.PutObject, got %s", span.Name)
+
+		// Internal, so it does not double-count the net/http client span.
+		verifier.Assert(span.SpanKind == trace.SpanKindInternal, "Expected span kind to be internal, got %v", span.SpanKind)
+
+		system := verifier.GetAttribute(span.Attributes, "rpc.system").AsString()
+		verifier.Assert(system == "aws-api", "Expected rpc.system to be aws-api, got %s", system)
+
+		service := verifier.GetAttribute(span.Attributes, "rpc.service").AsString()
+		verifier.Assert(service == "s3", "Expected rpc.service to be s3, got %s", service)
+
+		method := verifier.GetAttribute(span.Attributes, "rpc.method").AsString()
+		verifier.Assert(method == "PutObject", "Expected rpc.method to be PutObject, got %s", method)
+
+		verifier.Assert(verifier.GetAttribute(span.Attributes, "server.address").AsString() != "", "Expected server.address to be set")
+	}, 1)
+}

--- a/test/aws_sdk_go_tests.go
+++ b/test/aws_sdk_go_tests.go
@@ -22,12 +22,19 @@ const aws_sdk_go_module_name = "aws-sdk-go"
 func init() {
 	tc1 := NewGeneralTestCase("aws-sdk-go-s3-retry-test", aws_sdk_go_module_name, "v1.55.5", "", "1.24", "", TestAwsSdkGoS3Retry)
 	tc2 := NewMuzzleTestCase("aws-sdk-go-muzzle-test", aws_sdk_go_dependency_name, aws_sdk_go_module_name, "v1.55.5", "", "1.24", "", []string{"go", "build", "test_s3_retry.go"})
+	// The rule reaches session internals through go:linkname and the version
+	// range is left open, so the latest release has to be exercised, not just
+	// compiled against.
+	tc3 := NewLatestDepthTestCase("aws-sdk-go-latestdepth", aws_sdk_go_dependency_name, aws_sdk_go_module_name, "v1.55.5", "", "1.24", "", TestAwsSdkGoS3Retry)
 
 	if tc1 != nil {
 		TestCases = append(TestCases, tc1)
 	}
 	if tc2 != nil {
 		TestCases = append(TestCases, tc2)
+	}
+	if tc3 != nil {
+		TestCases = append(TestCases, tc3)
 	}
 }
 

--- a/test/aws_sdk_go_tests.go
+++ b/test/aws_sdk_go_tests.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import "testing"
+
+const aws_sdk_go_dependency_name = "github.com/aws/aws-sdk-go"
+const aws_sdk_go_module_name = "aws-sdk-go"
+
+func init() {
+	tc1 := NewGeneralTestCase("aws-sdk-go-s3-retry-test", aws_sdk_go_module_name, "v1.55.5", "", "1.24", "", TestAwsSdkGoS3Retry)
+	tc2 := NewMuzzleTestCase("aws-sdk-go-muzzle-test", aws_sdk_go_dependency_name, aws_sdk_go_module_name, "v1.55.5", "", "1.24", "", []string{"go", "build", "test_s3_retry.go"})
+
+	if tc1 != nil {
+		TestCases = append(TestCases, tc1)
+	}
+	if tc2 != nil {
+		TestCases = append(TestCases, tc2)
+	}
+}
+
+func TestAwsSdkGoS3Retry(t *testing.T, env ...string) {
+	UseApp("aws-sdk-go/v1.55.5")
+	RunGoBuild(t, "go", "build", "test_s3_retry.go")
+	RunApp(t, "./test_s3_retry", env...)
+}

--- a/test/world/go.mod
+++ b/test/world/go.mod
@@ -8,6 +8,7 @@ require (
 	dubbo.apache.org/dubbo-go/v3 v3.3.0
 	github.com/alibaba/sentinel-golang v1.0.4
 	github.com/apache/rocketmq-client-go/v2 v2.1.2
+	github.com/aws/aws-sdk-go v1.55.5
 	github.com/cloudwego/eino v0.3.51
 	github.com/cloudwego/eino-ext/components/model/ark v0.1.16
 	github.com/cloudwego/eino-ext/components/model/claude v0.1.1

--- a/test/world/main.go
+++ b/test/world/main.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/alibaba/sentinel-golang/api"
 	_ "github.com/apache/rocketmq-client-go/v2/consumer"
 	_ "github.com/apache/rocketmq-client-go/v2/producer"
+	_ "github.com/aws/aws-sdk-go/aws/session"
 	_ "github.com/cloudwego/eino-ext/components/model/ark"
 	_ "github.com/cloudwego/eino-ext/components/model/claude"
 	_ "github.com/cloudwego/eino-ext/components/model/ollama"

--- a/test/world_test.go
+++ b/test/world_test.go
@@ -22,7 +22,7 @@ import (
 
 const WorldAppName = "world"
 
-const expectedImportCounts = 40
+const expectedImportCounts = 41
 
 func TestCompileTheWorld(t *testing.T) {
 	UseApp(WorldAppName)

--- a/tool/data/rules/aws.json
+++ b/tool/data/rules/aws.json
@@ -1,11 +1,13 @@
 [
   {
+    "Version": "[1.55.5,)",
     "ImportPath": "github.com/aws/aws-sdk-go/aws/session",
     "Function": "NewSession",
     "OnExit": "newSessionOnExit",
     "Path": "github.com/alibaba/loongsuite-go/pkg/rules/aws-sdk-go"
   },
   {
+    "Version": "[1.55.5,)",
     "ImportPath": "github.com/aws/aws-sdk-go/aws/session",
     "Function": "NewSessionWithOptions",
     "OnExit": "newSessionWithOptionsOnExit",

--- a/tool/data/rules/aws.json
+++ b/tool/data/rules/aws.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ImportPath": "github.com/aws/aws-sdk-go/aws/session",
+    "Function": "NewSession",
+    "OnExit": "newSessionOnExit",
+    "Path": "github.com/alibaba/loongsuite-go/pkg/rules/aws-sdk-go"
+  },
+  {
+    "ImportPath": "github.com/aws/aws-sdk-go/aws/session",
+    "Function": "NewSessionWithOptions",
+    "OnExit": "newSessionWithOptionsOnExit",
+    "Path": "github.com/alibaba/loongsuite-go/pkg/rules/aws-sdk-go"
+  }
+]


### PR DESCRIPTION
Fixes the intermittent S3 `403 AccessDenied` described in #742.

## Problem

The generic net/http instrumentation injects the W3C `traceparent` header at `Transport.RoundTrip`. This conflicts with aws-sdk-go's *sign-then-send + retry* model:

1. First attempt: aws-sdk signs (no `traceparent` in header yet) → `traceparent` not in `SignedHeaders` → RoundTrip injects it → **200**.
2. Server returns `503 SlowDown` → aws-sdk **retries, reusing the same `*http.Request`**, whose header still carries the previously injected `traceparent`.
3. Retry: aws-sdk **re-signs**; now `traceparent` is present, so it gets folded into `SignedHeaders` (aws-sdk-go's SigV4 `ignoredHeaders` covers `X-Amzn-Trace-Id` but not W3C `traceparent`).
4. RoundTrip re-injects `traceparent` with a new span id, overwriting the value.
5. Signed value ≠ sent value → signature verification fails → **403**.

Failure rate scales with volume/retries. First attempts succeed, retries fail — which is why objects still land in the bucket while 403s accumulate.

## Fix

A dedicated `aws-sdk-go` rule (mirroring the existing `anthropic-sdk-go` / `openai-go` rules) that hooks `session.NewSession` / `NewSessionWithOptions` and, on the returned session's handlers:

1. **Correctness** — strips `traceparent`/`tracestate` in a `Sign.PushFront` handler, *before* SigV4 signing, so trace headers can never enter `SignedHeaders` and thus can never corrupt the signature (regardless of later RoundTrip injection or retries).
2. **Observability** — emits a client span per SDK operation via the SDK handler chain (`Send`/`Complete`), so aws-sdk calls remain traced **without** propagating trace context through signed HTTP headers.

## Files

- `pkg/rules/aws-sdk-go/setup.go` — the rule (onExit hooks + handler installation)
- `pkg/rules/aws-sdk-go/go.mod`
- `tool/data/rules/aws.json` — rule registration

## Verification

- `go build ./...` and `go vet ./...` pass for the new rule package.
- End-to-end injection (compiling a real aws-sdk-go program with `otel go build` and confirming retried S3 requests no longer 403) has **not** been run locally; happy to add an integration test or adjust if the project has a preferred harness for SDK rules. Feedback on the approach is welcome.
