### PR TITLE
fix(fasthttp): remove upper version bound so latest releases stay instrumented

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The detailed usage of `otel` tool can be found in [**Usage**](./docs/user/config
 | echo               | https://github.com/labstack/echo                | v4.0.0      | -           |
 | elasticsearch      | https://github.com/elastic/go-elasticsearch     | v8.4.0      | v8.15.1     |
 | eino               | https://github.com/cloudwego/eino               | v0.3.51     | -           |
-| fasthttp           | https://github.com/valyala/fasthttp             | v1.45.0     | v1.65.1     |
+| fasthttp           | https://github.com/valyala/fasthttp             | v1.45.0     | -           |
 | fiber              | https://github.com/gofiber/fiber                | v2.43.0     | v2.52.13    |
 | fiber/v3           | https://github.com/gofiber/fiber/v3             | v3.0.0      | -           |
 | franz-go           | https://github.com/twmb/franz-go                | v1.18.0     | -           |

--- a/docs/user/supported-libraries.md
+++ b/docs/user/supported-libraries.md
@@ -13,7 +13,7 @@
 | echo               | https://github.com/labstack/echo                  | v4.0.0      | -           |
 | elasticsearch      | https://github.com/elastic/go-elasticsearch       | v8.4.0      | v8.15.1     |
 | eino               | https://github.com/cloudwego/eino                 | v0.3.51     | -           |
-| fasthttp           | https://github.com/valyala/fasthttp               | v1.45.0     | v1.65.1     |
+| fasthttp           | https://github.com/valyala/fasthttp               | v1.45.0     | -           |
 | fiber              | https://github.com/gofiber/fiber                  | v2.43.0     | v2.52.13    |
 | franz-go           | https://github.com/twmb/franz-go                  | v1.18.0     | -           |
 | gin                | https://github.com/gin-gonic/gin                  | v1.7.0      | v1.10.2     |

--- a/docs/zh/user/supported-libraries.md
+++ b/docs/zh/user/supported-libraries.md
@@ -13,7 +13,7 @@
 | echo                | https://github.com/labstack/echo                            | v4.0.0      | -           |
 | elasticsearch       | https://github.com/elastic/go-elasticsearch                 | v8.4.0      | v8.15.1     |
 | eino                | https://github.com/cloudwego/eino                           | v0.3.51     | -           |
-| fasthttp            | https://github.com/valyala/fasthttp                         | v1.45.0     | v1.65.1     |
+| fasthttp            | https://github.com/valyala/fasthttp                         | v1.45.0     | -           |
 | fiber               | https://github.com/gofiber/fiber                            | v2.43.0     | v2.52.13    |
 | franz-go            | https://github.com/twmb/franz-go                            | v1.18.0     | -           |
 | gin                 | https://github.com/gin-gonic/gin                            | v1.7.0      | v1.10.2     |

--- a/test/fasthttp_tests.go
+++ b/test/fasthttp_tests.go
@@ -27,7 +27,9 @@ func init() {
 		NewGeneralTestCase("fasthttp-capture-disabled-test", fasthttp_module_name, "", "", "1.18", "", TestFastHttpCaptureDisabled),
 		NewGeneralTestCase("fasthttp-capture-headers-only-test", fasthttp_module_name, "", "", "1.18", "", TestFastHttpCaptureHeadersOnly),
 		NewGeneralTestCase("fasthttp-capture-body-only-test", fasthttp_module_name, "", "", "1.18", "", TestFastHttpCaptureBodyOnly),
-		NewLatestDepthTestCase("fasthttp-latestdepth", fasthttp_dependency_name, fasthttp_module_name, "v1.45.0", "v1.65.0", "1.18", "", TestBasicFastHttp),
+		// fasthttp v1.73.0 and above declare `go 1.25.0` in their go.mod, so the
+		// latest-depth check requires go 1.25.
+		NewLatestDepthTestCase("fasthttp-latestdepth", fasthttp_dependency_name, fasthttp_module_name, "v1.45.0", "", "1.25", "", TestBasicFastHttp),
 		NewMuzzleTestCase("fasthttp-muzzle", fasthttp_dependency_name, fasthttp_module_name, "v1.45.0", "", "1.18", "", []string{"go", "build", "test_basic_http.go", "server.go"}))
 }
 

--- a/tool/data/rules/fasthttp.json
+++ b/tool/data/rules/fasthttp.json
@@ -1,6 +1,6 @@
 [
   {
-    "Version": "[1.45.0,1.73.0)",
+    "Version": "[1.45.0,)",
     "ImportPath": "github.com/valyala/fasthttp",
     "Function": "Do",
     "ReceiverType": "\\*HostClient",
@@ -9,7 +9,7 @@
     "Path": "github.com/alibaba/loongsuite-go/pkg/rules/fasthttp"
   },
   {
-    "Version": "[1.45.0,1.73.0)",
+    "Version": "[1.45.0,)",
     "ImportPath": "github.com/valyala/fasthttp",
     "Function": "ListenAndServe",
     "ReceiverType": "\\*Server",


### PR DESCRIPTION
## Problem

`TestLatest2/fiberv3-latestdepth` and `TestLatest2/fiberv3-custom-ctx-latestdepth` fail in the Latest workflow:

```
panic: Expect to be client span, got 2
	test/verifier/verifier.go:48  VerifyHttpClientAttributes
	test/fiberv3/v3.0.0/fiber_http.go:75
```

The debug dump shows the trace contains a single span — the fiber server span — with no fasthttp client span:

```
[test debugging] trace:0
[test debugging] GET /fiber
...
[test debugging] http.route {4 0 /fiber <nil>}
panic: Expect to be client span, got 2
```

## Root cause

`tool/data/rules/fasthttp.json` pinned both rules to `[1.45.0,1.73.0)`.

fasthttp `v1.73.0` was released 2026-07-27, and `gofiber/fiber/v3 v3.5.0` (what latest-depth resolves to) requires exactly that version:

```
$ curl -s https://proxy.golang.org/github.com/gofiber/fiber/v3/@v/v3.5.0.mod | grep fasthttp
	github.com/valyala/fasthttp v1.73.0
```

So the latest-depth build pulled in a fasthttp the rules no longer match, the `(*HostClient).Do` hook was never applied, and no client span was produced. `stubs[0][0]` then resolved to the fiber server span, which is what the assertion reports.

## Fix

Drop the upper bound: `[1.45.0,1.73.0)` -> `[1.45.0,)`.

The bound was never a real compatibility boundary — it has been bumped reactively three times (`1.64.1` -> `1.65.1` -> `1.70.0` -> `1.73.0`), each time only after CI had already broken, and it never excluded an incompatible release. Both hooked functions have kept stable signatures since v1.45.0:

| version | `(*HostClient).Do` | `(*Server).ListenAndServe` |
|---|---|---|
| v1.69.0 | `func(req *Request, resp *Response) error` | `func(addr string) error` |
| v1.72.0 | same | same |
| v1.73.0 | same | same |

Open-ended ranges are also the norm in this repo (222 of 296 rule entries), so new fasthttp releases now stay instrumented by default instead of silently losing spans until someone notices a red CI run.

Also uncapped `fasthttp-latestdepth`, which was pinned to `v1.65.0` — that cap is why this regression surfaced through fiberv3 rather than through the fasthttp plugin's own latest-depth test. It asserts a client span (`test/fasthttp/v1.45.0/test_basic_http.go:48`), so with the cap removed it guards this exact failure mode going forward. Since fasthttp v1.73.0 declares `go 1.25.0`, that case now requires go 1.25 (the Latest jobs already have a 1.25 matrix leg).

Docs (`README.md`, `docs/user/supported-libraries.md`, `docs/zh/user/supported-libraries.md`) updated to show `-` as max version, consistent with other open-ended libraries. They still listed `v1.65.1`, two bumps behind the rule file.

## Verification

Reproduced and verified locally with go 1.25.6 (fiber v3.5.0, fasthttp v1.73.0).

Before the fix:

```
--- FAIL: TestLatest4/fiberv3-latestdepth (48.99s)
        panic: Expect to be client span, got 2
```

After the fix:

```
--- PASS: TestLatest4/fiberv3-latestdepth (26.80s)
--- PASS: TestLatest4/fiberv3-custom-ctx-latestdepth (48.11s)
--- PASS: TestLatest4/fasthttp-latestdepth (34.79s)      # resolves v1.73.0
--- PASS: TestPlugins4/basic-fasthttp-test (30.74s)      # pinned v1.56.0, unaffected
```

Note: `TestLatest2/test_gocql_latestdepth_crud` appears next to these failures in the log but passed (`--- PASS: TestLatest2/test_gocql_latestdepth_crud (93.43s)`); gocql latest is still v1.7.0, inside its `[1.3.0,1.7.1)` range.
