### PR TITLE
feat(sdk): support the standard OTEL_TRACES_SAMPLER environment variables

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Build
       run: make build
     - name: InstUt
-      run: cd pkg && go test -a -v ./inst-api/... ./inst-api-semconv/... ./testaccess/... -coverprofile=coverage.txt -covermode=atomic
+      run: cd pkg && go test -a -v ./inst-api/... ./inst-api-semconv/... ./sdkconfig/... ./testaccess/... -coverprofile=coverage.txt -covermode=atomic
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.0.1
       with:

--- a/docs/user/sdk-config.md
+++ b/docs/user/sdk-config.md
@@ -21,8 +21,12 @@ In addition to automatic instrumentation, the `otel` tool injects configuration 
   - `traceidratio`, `parentbased_traceidratio`: the ratio is read from `OTEL_TRACES_SAMPLER_ARG`
   - `parentbased_always_on` (specification default), `parentbased_always_off`
   - `jaeger_remote`, `parentbased_jaeger_remote` and `xray` are not supported and fall back to the default sampler.
-- `OTEL_TRACES_SAMPLER_ARG`: Argument for the selected sampler. For the `*_traceidratio` samplers it is a floating-point number between 0.0 and 1.0; a missing, unparsable or out-of-range value falls back to `1.0`.
+- `OTEL_TRACES_SAMPLER_ARG`: Argument for the selected sampler. It is only read by the `traceidratio` and `parentbased_traceidratio` samplers and ignored by the others. It is a floating-point number between 0.0 and 1.0; a missing, unparsable or out-of-range value is logged and falls back to `1.0`.
 - `OTEL_TRACE_SAMPLER`: Agent-specific shorthand that predates the standard variables and **takes precedence over them** when set. A floating-point number between 0.0 and 1.0 sets a ratio-based sampler. Values <= 0 will never sample, and values >= 1 will always sample.
 
   When neither `OTEL_TRACE_SAMPLER` nor `OTEL_TRACES_SAMPLER` is set, the default is a parent-based sampler that always samples.
+
+  Note that the two variables are not interchangeable: `OTEL_TRACE_SAMPLER=0.5` builds a **parent-based** ratio sampler, whereas `OTEL_TRACES_SAMPLER=traceidratio` with `OTEL_TRACES_SAMPLER_ARG=0.5` builds a **non** parent-based one. Use `parentbased_traceidratio` to keep the previous behaviour.
+
+  **Upgrading**: releases before standard sampler support ignored `OTEL_TRACES_SAMPLER` entirely. If your platform already injects it, sampling will change once you upgrade. Set `OTEL_TRACE_SAMPLER` explicitly to keep the sampler you have today.
 - `OTEL_INSTRUMENTATION_HTTP_EXCLUDE_PATHS`: Specifies a regular expression pattern to exclude URL paths from HTTP auto-instrumentation (e.g., `^/(ping|health|metrics)$`). Requests whose paths match the pattern will not generate spans. By default, no paths are excluded.

--- a/docs/user/sdk-config.md
+++ b/docs/user/sdk-config.md
@@ -16,5 +16,13 @@ In addition to automatic instrumentation, the `otel` tool injects configuration 
   - `cumulative` (default): All instrument kinds use Cumulative temporality
   - `delta`: Counter, Asynchronous Counter, and Histogram use Delta temporality; UpDownCounter and Asynchronous UpDownCounter use Cumulative temporality
   - `lowmemory`: Synchronous Counter and Histogram use Delta temporality; other types use Cumulative temporality (low memory mode)
-- `OTEL_TRACE_SAMPLER`: Specifies the trace sampler. A floating-point number between 0.0 and 1.0 sets a ratio-based sampler. Values <= 0 will never sample, and values >= 1 will always sample. The default is a parent-based sampler that always samples.
+- `OTEL_TRACES_SAMPLER`: Specifies the trace sampler using the standard OpenTelemetry SDK values (case-insensitive). Supported values:
+  - `always_on`, `always_off`
+  - `traceidratio`, `parentbased_traceidratio`: the ratio is read from `OTEL_TRACES_SAMPLER_ARG`
+  - `parentbased_always_on` (specification default), `parentbased_always_off`
+  - `jaeger_remote`, `parentbased_jaeger_remote` and `xray` are not supported and fall back to the default sampler.
+- `OTEL_TRACES_SAMPLER_ARG`: Argument for the selected sampler. For the `*_traceidratio` samplers it is a floating-point number between 0.0 and 1.0; a missing, unparsable or out-of-range value falls back to `1.0`.
+- `OTEL_TRACE_SAMPLER`: Agent-specific shorthand that predates the standard variables and **takes precedence over them** when set. A floating-point number between 0.0 and 1.0 sets a ratio-based sampler. Values <= 0 will never sample, and values >= 1 will always sample.
+
+  When neither `OTEL_TRACE_SAMPLER` nor `OTEL_TRACES_SAMPLER` is set, the default is a parent-based sampler that always samples.
 - `OTEL_INSTRUMENTATION_HTTP_EXCLUDE_PATHS`: Specifies a regular expression pattern to exclude URL paths from HTTP auto-instrumentation (e.g., `^/(ping|health|metrics)$`). Requests whose paths match the pattern will not generate spans. By default, no paths are excluded.

--- a/docs/zh/user/sdk-config.md
+++ b/docs/zh/user/sdk-config.md
@@ -21,8 +21,12 @@
   - `traceidratio`、`parentbased_traceidratio`：采样比率从 `OTEL_TRACES_SAMPLER_ARG` 读取
   - `parentbased_always_on`（规范默认值）、`parentbased_always_off`
   - `jaeger_remote`、`parentbased_jaeger_remote` 和 `xray` 暂不支持，会回退到默认采样器。
-- `OTEL_TRACES_SAMPLER_ARG`: 所选采样器的参数。对于 `*_traceidratio` 采样器，它是 0.0 到 1.0 之间的浮点数；未设置、无法解析或超出范围时回退为 `1.0`。
+- `OTEL_TRACES_SAMPLER_ARG`: 所选采样器的参数。它仅被 `traceidratio` 和 `parentbased_traceidratio` 采样器读取，其余采样器会忽略它。取值为 0.0 到 1.0 之间的浮点数；未设置、无法解析或超出范围时会记录日志并回退为 `1.0`。
 - `OTEL_TRACE_SAMPLER`: 早于标准变量引入的 Agent 私有配置，设置后**优先级高于标准变量**。0.0 到 1.0 之间的浮点数会设置一个基于比率的采样器。小于等于 0 的值将永不采样，大于等于 1 的值将始终采样。
 
   当 `OTEL_TRACE_SAMPLER` 和 `OTEL_TRACES_SAMPLER` 都未设置时，默认是基于父级的采样器，并且始终采样。
+
+  注意两个变量并不等价：`OTEL_TRACE_SAMPLER=0.5` 构建的是**基于父级的**比率采样器，而 `OTEL_TRACES_SAMPLER=traceidratio` 配合 `OTEL_TRACES_SAMPLER_ARG=0.5` 构建的是**非**基于父级的采样器。若要保持原有行为，请使用 `parentbased_traceidratio`。
+
+  **升级提示**：支持标准采样器变量之前的版本会完全忽略 `OTEL_TRACES_SAMPLER`。如果你的平台已经注入了该变量，升级后采样行为会发生变化。显式设置 `OTEL_TRACE_SAMPLER` 可保持当前的采样器不变。
 - `OTEL_INSTRUMENTATION_HTTP_EXCLUDE_PATHS`: 指定要从 HTTP 自动埋点中排除的 URL 路径正则表达式（例如 `^/(ping|health|metrics)$`）。路径匹配该正则表达式的请求将不会生成 span。默认不排除任何路径。

--- a/docs/zh/user/sdk-config.md
+++ b/docs/zh/user/sdk-config.md
@@ -16,5 +16,13 @@
   - `cumulative` (默认): 所有指标类型都使用累积时间性
   - `delta`: Counter、Asynchronous Counter 和 Histogram 使用增量时间性；UpDownCounter 和 Asynchronous UpDownCounter 使用累积时间性
   - `lowmemory`: Synchronous Counter 和 Histogram 使用增量时间性；其他类型使用累积时间性（低内存模式）
-- `OTEL_TRACE_SAMPLER`: 指定链路采样器。0.0 到 1.0 之间的浮点数会设置一个基于比率的采样器。小于等于 0 的值将永不采样，大于等于 1 的值将始终采样。默认是基于父级的采样器，并且始终采样。
+- `OTEL_TRACES_SAMPLER`: 使用 OpenTelemetry SDK 标准取值指定链路采样器（大小写不敏感）。支持的值：
+  - `always_on`、`always_off`
+  - `traceidratio`、`parentbased_traceidratio`：采样比率从 `OTEL_TRACES_SAMPLER_ARG` 读取
+  - `parentbased_always_on`（规范默认值）、`parentbased_always_off`
+  - `jaeger_remote`、`parentbased_jaeger_remote` 和 `xray` 暂不支持，会回退到默认采样器。
+- `OTEL_TRACES_SAMPLER_ARG`: 所选采样器的参数。对于 `*_traceidratio` 采样器，它是 0.0 到 1.0 之间的浮点数；未设置、无法解析或超出范围时回退为 `1.0`。
+- `OTEL_TRACE_SAMPLER`: 早于标准变量引入的 Agent 私有配置，设置后**优先级高于标准变量**。0.0 到 1.0 之间的浮点数会设置一个基于比率的采样器。小于等于 0 的值将永不采样，大于等于 1 的值将始终采样。
+
+  当 `OTEL_TRACE_SAMPLER` 和 `OTEL_TRACES_SAMPLER` 都未设置时，默认是基于父级的采样器，并且始终采样。
 - `OTEL_INSTRUMENTATION_HTTP_EXCLUDE_PATHS`: 指定要从 HTTP 自动埋点中排除的 URL 路径正则表达式（例如 `^/(ping|health|metrics)$`）。路径匹配该正则表达式的请求将不会生成 span。默认不排除任何路径。

--- a/pkg/otel_setup.go
+++ b/pkg/otel_setup.go
@@ -22,7 +22,6 @@ import (
 	http2 "net/http"
 	"os"
 	"runtime"
-	"strconv"
 	"strings"
 
 	"github.com/alibaba/loongsuite-go/pkg/core/meter"
@@ -31,6 +30,7 @@ import (
 	"github.com/alibaba/loongsuite-go/pkg/inst-api-semconv/instrumenter/experimental"
 	"github.com/alibaba/loongsuite-go/pkg/inst-api-semconv/instrumenter/http"
 	"github.com/alibaba/loongsuite-go/pkg/inst-api-semconv/instrumenter/rpc"
+	"github.com/alibaba/loongsuite-go/pkg/sdkconfig"
 	testaccess "github.com/alibaba/loongsuite-go/pkg/testaccess"
 	prometheus_client "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -68,17 +68,6 @@ const trace_exporter = "OTEL_TRACES_EXPORTER"
 const prometheus_exporter_port = "OTEL_EXPORTER_PROMETHEUS_PORT"
 const default_prometheus_exporter_port = "9464"
 const metrics_temporality_preference = "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"
-
-const trace_sampler = "OTEL_TRACE_SAMPLER"
-
-// Standard OpenTelemetry SDK sampler configuration.
-// https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
-const traces_sampler = "OTEL_TRACES_SAMPLER"
-const traces_sampler_arg = "OTEL_TRACES_SAMPLER_ARG"
-
-// Ratio used when a *_traceidratio sampler is selected without a usable
-// OTEL_TRACES_SAMPLER_ARG, as required by the specification.
-const default_sampler_ratio = 1.0
 
 var (
 	metricExporters    []metric.Exporter
@@ -189,85 +178,6 @@ func createTraceExporter(ctx context.Context, name string) (trace.SpanExporter, 
 	}
 }
 
-func newSpanSampler() trace.Sampler {
-	// OTEL_TRACE_SAMPLER is specific to this agent and predates the standard
-	// variables, so it keeps precedence for deployments already using it.
-	if samplerStr := strings.TrimSpace(os.Getenv(trace_sampler)); samplerStr != "" {
-		return newRatioSampler(samplerStr)
-	}
-
-	if samplerStr := strings.TrimSpace(os.Getenv(traces_sampler)); samplerStr != "" {
-		return newStandardSampler(samplerStr, os.Getenv(traces_sampler_arg))
-	}
-
-	// Equivalent to the specification default, parentbased_always_on.
-	return trace.ParentBased(trace.AlwaysSample())
-}
-
-// newRatioSampler handles OTEL_TRACE_SAMPLER, which takes a bare ratio.
-func newRatioSampler(samplerStr string) trace.Sampler {
-	sampler, err := strconv.ParseFloat(samplerStr, 64)
-	if err != nil {
-		log.Printf("Invalid OTEL_TRACE_SAMPLER value: %s, fallback to parent based sampler", samplerStr)
-		return trace.ParentBased(trace.AlwaysSample())
-	}
-
-	if sampler <= 0 {
-		return trace.NeverSample()
-	} else if sampler >= 1 {
-		return trace.AlwaysSample()
-	} else {
-		return trace.ParentBased(trace.TraceIDRatioBased(sampler))
-	}
-}
-
-// newStandardSampler handles OTEL_TRACES_SAMPLER / OTEL_TRACES_SAMPLER_ARG as
-// defined by the OpenTelemetry SDK environment variable specification.
-func newStandardSampler(name, arg string) trace.Sampler {
-	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "always_on":
-		return trace.AlwaysSample()
-	case "always_off":
-		return trace.NeverSample()
-	case "traceidratio":
-		return trace.TraceIDRatioBased(parseSamplerRatio(arg))
-	case "parentbased_always_on":
-		return trace.ParentBased(trace.AlwaysSample())
-	case "parentbased_always_off":
-		return trace.ParentBased(trace.NeverSample())
-	case "parentbased_traceidratio":
-		return trace.ParentBased(trace.TraceIDRatioBased(parseSamplerRatio(arg)))
-	default:
-		// jaeger_remote, parentbased_jaeger_remote and xray need samplers that
-		// are not linked into the agent.
-		log.Printf("Unsupported OTEL_TRACES_SAMPLER value: %s, fallback to parent based sampler", name)
-		return trace.ParentBased(trace.AlwaysSample())
-	}
-}
-
-// parseSamplerRatio reads OTEL_TRACES_SAMPLER_ARG for the *_traceidratio
-// samplers. The specification says to log and fall back to the default ratio
-// when the value is missing or cannot be used.
-func parseSamplerRatio(arg string) float64 {
-	arg = strings.TrimSpace(arg)
-	if arg == "" {
-		return default_sampler_ratio
-	}
-
-	ratio, err := strconv.ParseFloat(arg, 64)
-	if err != nil {
-		log.Printf("Invalid OTEL_TRACES_SAMPLER_ARG value: %s, fallback to ratio %v", arg, default_sampler_ratio)
-		return default_sampler_ratio
-	}
-
-	if ratio < 0 || ratio > 1 {
-		log.Printf("Out of range OTEL_TRACES_SAMPLER_ARG value: %s, fallback to ratio %v", arg, default_sampler_ratio)
-		return default_sampler_ratio
-	}
-
-	return ratio
-}
-
 func getTemporalitySelector() metric.TemporalitySelector {
 	pref := strings.ToLower(strings.TrimSpace(os.Getenv(metrics_temporality_preference)))
 	
@@ -325,7 +235,7 @@ func lowMemoryTemporalitySelector(ik metric.InstrumentKind) metricdata.Temporali
 
 func initOpenTelemetry(ctx context.Context) error {
 	processors := newSpanProcessors(ctx)
-	spanSampler = newSpanSampler()
+	spanSampler = sdkconfig.NewSpanSampler()
 
 	var options []trace.TracerProviderOption
 	if len(processors) > 0 {

--- a/pkg/otel_setup.go
+++ b/pkg/otel_setup.go
@@ -71,6 +71,15 @@ const metrics_temporality_preference = "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_P
 
 const trace_sampler = "OTEL_TRACE_SAMPLER"
 
+// Standard OpenTelemetry SDK sampler configuration.
+// https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
+const traces_sampler = "OTEL_TRACES_SAMPLER"
+const traces_sampler_arg = "OTEL_TRACES_SAMPLER_ARG"
+
+// Ratio used when a *_traceidratio sampler is selected without a usable
+// OTEL_TRACES_SAMPLER_ARG, as required by the specification.
+const default_sampler_ratio = 1.0
+
 var (
 	metricExporters    []metric.Exporter
 	spanExporters      []trace.SpanExporter
@@ -181,12 +190,22 @@ func createTraceExporter(ctx context.Context, name string) (trace.SpanExporter, 
 }
 
 func newSpanSampler() trace.Sampler {
-	samplerStr := os.Getenv(trace_sampler)
-	samplerStr = strings.TrimSpace(samplerStr)
-	if samplerStr == "" {
-		return trace.ParentBased(trace.AlwaysSample())
+	// OTEL_TRACE_SAMPLER is specific to this agent and predates the standard
+	// variables, so it keeps precedence for deployments already using it.
+	if samplerStr := strings.TrimSpace(os.Getenv(trace_sampler)); samplerStr != "" {
+		return newRatioSampler(samplerStr)
 	}
 
+	if samplerStr := strings.TrimSpace(os.Getenv(traces_sampler)); samplerStr != "" {
+		return newStandardSampler(samplerStr, os.Getenv(traces_sampler_arg))
+	}
+
+	// Equivalent to the specification default, parentbased_always_on.
+	return trace.ParentBased(trace.AlwaysSample())
+}
+
+// newRatioSampler handles OTEL_TRACE_SAMPLER, which takes a bare ratio.
+func newRatioSampler(samplerStr string) trace.Sampler {
 	sampler, err := strconv.ParseFloat(samplerStr, 64)
 	if err != nil {
 		log.Printf("Invalid OTEL_TRACE_SAMPLER value: %s, fallback to parent based sampler", samplerStr)
@@ -200,6 +219,53 @@ func newSpanSampler() trace.Sampler {
 	} else {
 		return trace.ParentBased(trace.TraceIDRatioBased(sampler))
 	}
+}
+
+// newStandardSampler handles OTEL_TRACES_SAMPLER / OTEL_TRACES_SAMPLER_ARG as
+// defined by the OpenTelemetry SDK environment variable specification.
+func newStandardSampler(name, arg string) trace.Sampler {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "always_on":
+		return trace.AlwaysSample()
+	case "always_off":
+		return trace.NeverSample()
+	case "traceidratio":
+		return trace.TraceIDRatioBased(parseSamplerRatio(arg))
+	case "parentbased_always_on":
+		return trace.ParentBased(trace.AlwaysSample())
+	case "parentbased_always_off":
+		return trace.ParentBased(trace.NeverSample())
+	case "parentbased_traceidratio":
+		return trace.ParentBased(trace.TraceIDRatioBased(parseSamplerRatio(arg)))
+	default:
+		// jaeger_remote, parentbased_jaeger_remote and xray need samplers that
+		// are not linked into the agent.
+		log.Printf("Unsupported OTEL_TRACES_SAMPLER value: %s, fallback to parent based sampler", name)
+		return trace.ParentBased(trace.AlwaysSample())
+	}
+}
+
+// parseSamplerRatio reads OTEL_TRACES_SAMPLER_ARG for the *_traceidratio
+// samplers. The specification says to log and fall back to the default ratio
+// when the value is missing or cannot be used.
+func parseSamplerRatio(arg string) float64 {
+	arg = strings.TrimSpace(arg)
+	if arg == "" {
+		return default_sampler_ratio
+	}
+
+	ratio, err := strconv.ParseFloat(arg, 64)
+	if err != nil {
+		log.Printf("Invalid OTEL_TRACES_SAMPLER_ARG value: %s, fallback to ratio %v", arg, default_sampler_ratio)
+		return default_sampler_ratio
+	}
+
+	if ratio < 0 || ratio > 1 {
+		log.Printf("Out of range OTEL_TRACES_SAMPLER_ARG value: %s, fallback to ratio %v", arg, default_sampler_ratio)
+		return default_sampler_ratio
+	}
+
+	return ratio
 }
 
 func getTemporalitySelector() metric.TemporalitySelector {

--- a/pkg/sdkconfig/sampler.go
+++ b/pkg/sdkconfig/sampler.go
@@ -96,10 +96,13 @@ func newStandardSampler(name, arg string) trace.Sampler {
 		return trace.ParentBased(trace.NeverSample())
 	case "parentbased_traceidratio":
 		return trace.ParentBased(trace.TraceIDRatioBased(parseSamplerRatio(arg)))
+	case "jaeger_remote", "parentbased_jaeger_remote", "xray":
+		// Valid names, but they need samplers that are not linked into the
+		// agent.
+		log.Printf("OTEL_TRACES_SAMPLER=%s is not supported (remote and X-Ray samplers are not linked into the agent), fallback to parent based sampler", name)
+		return trace.ParentBased(trace.AlwaysSample())
 	default:
-		// jaeger_remote, parentbased_jaeger_remote and xray need samplers that
-		// are not linked into the agent.
-		log.Printf("Unsupported OTEL_TRACES_SAMPLER value: %s, fallback to parent based sampler", name)
+		log.Printf("Unknown OTEL_TRACES_SAMPLER value: %s, fallback to parent based sampler", name)
 		return trace.ParentBased(trace.AlwaysSample())
 	}
 }

--- a/pkg/sdkconfig/sampler.go
+++ b/pkg/sdkconfig/sampler.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sdkconfig turns the OpenTelemetry SDK environment variables into
+// SDK objects. It deliberately holds no references to the symbols the agent
+// injects at build time, so it can be exercised by ordinary unit tests.
+package sdkconfig
+
+import (
+	"log"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+// Agent-specific sampler variable, kept for deployments that already use it.
+const trace_sampler = "OTEL_TRACE_SAMPLER"
+
+// Standard OpenTelemetry SDK sampler configuration.
+// https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
+const traces_sampler = "OTEL_TRACES_SAMPLER"
+const traces_sampler_arg = "OTEL_TRACES_SAMPLER_ARG"
+
+// Ratio used when a *_traceidratio sampler is selected without a usable
+// OTEL_TRACES_SAMPLER_ARG, as required by the specification.
+const default_sampler_ratio = 1.0
+
+// NewSpanSampler builds the sampler described by the environment.
+func NewSpanSampler() trace.Sampler {
+	legacy := strings.TrimSpace(os.Getenv(trace_sampler))
+	standard := strings.TrimSpace(os.Getenv(traces_sampler))
+
+	// OTEL_TRACE_SAMPLER is specific to this agent and predates the standard
+	// variables, so it keeps precedence for deployments already using it.
+	if legacy != "" {
+		if standard != "" {
+			log.Printf("Both %s and %s are set, %s takes precedence and %s=%s is ignored",
+				trace_sampler, traces_sampler, trace_sampler, traces_sampler, standard)
+		}
+
+		return newRatioSampler(legacy)
+	}
+
+	if standard != "" {
+		return newStandardSampler(standard, os.Getenv(traces_sampler_arg))
+	}
+
+	// Equivalent to the specification default, parentbased_always_on.
+	return trace.ParentBased(trace.AlwaysSample())
+}
+
+// newRatioSampler handles OTEL_TRACE_SAMPLER, which takes a bare ratio.
+func newRatioSampler(samplerStr string) trace.Sampler {
+	sampler, err := strconv.ParseFloat(samplerStr, 64)
+	if err != nil {
+		log.Printf("Invalid OTEL_TRACE_SAMPLER value: %s, fallback to parent based sampler", samplerStr)
+		return trace.ParentBased(trace.AlwaysSample())
+	}
+
+	if sampler <= 0 {
+		return trace.NeverSample()
+	} else if sampler >= 1 {
+		return trace.AlwaysSample()
+	} else {
+		return trace.ParentBased(trace.TraceIDRatioBased(sampler))
+	}
+}
+
+// newStandardSampler handles OTEL_TRACES_SAMPLER / OTEL_TRACES_SAMPLER_ARG as
+// defined by the OpenTelemetry SDK environment variable specification.
+func newStandardSampler(name, arg string) trace.Sampler {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "always_on":
+		return trace.AlwaysSample()
+	case "always_off":
+		return trace.NeverSample()
+	case "traceidratio":
+		return trace.TraceIDRatioBased(parseSamplerRatio(arg))
+	case "parentbased_always_on":
+		return trace.ParentBased(trace.AlwaysSample())
+	case "parentbased_always_off":
+		return trace.ParentBased(trace.NeverSample())
+	case "parentbased_traceidratio":
+		return trace.ParentBased(trace.TraceIDRatioBased(parseSamplerRatio(arg)))
+	default:
+		// jaeger_remote, parentbased_jaeger_remote and xray need samplers that
+		// are not linked into the agent.
+		log.Printf("Unsupported OTEL_TRACES_SAMPLER value: %s, fallback to parent based sampler", name)
+		return trace.ParentBased(trace.AlwaysSample())
+	}
+}
+
+// parseSamplerRatio reads OTEL_TRACES_SAMPLER_ARG for the *_traceidratio
+// samplers. Anything the specification does not allow is logged and falls back
+// to the default ratio.
+func parseSamplerRatio(arg string) float64 {
+	arg = strings.TrimSpace(arg)
+	if arg == "" {
+		log.Printf("Missing OTEL_TRACES_SAMPLER_ARG, fallback to ratio %v", default_sampler_ratio)
+		return default_sampler_ratio
+	}
+
+	ratio, err := strconv.ParseFloat(arg, 64)
+	if err != nil {
+		log.Printf("Invalid OTEL_TRACES_SAMPLER_ARG value: %s, fallback to ratio %v", arg, default_sampler_ratio)
+		return default_sampler_ratio
+	}
+
+	// NaN has to be rejected explicitly: every comparison against it is false,
+	// so a range check alone lets it through.
+	if math.IsNaN(ratio) || math.IsInf(ratio, 0) || ratio < 0 || ratio > 1 {
+		log.Printf("Out of range OTEL_TRACES_SAMPLER_ARG value: %s, fallback to ratio %v", arg, default_sampler_ratio)
+		return default_sampler_ratio
+	}
+
+	return ratio
+}

--- a/pkg/sdkconfig/sampler_test.go
+++ b/pkg/sdkconfig/sampler_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdkconfig
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewSpanSampler(t *testing.T) {
+	const parentBasedAlwaysOn = "ParentBased{root:AlwaysOnSampler"
+
+	tests := []struct {
+		name     string
+		legacy   string
+		standard string
+		arg      string
+		want     string
+	}{
+		// Nothing configured keeps the pre-existing default.
+		{"unset", "", "", "", parentBasedAlwaysOn},
+
+		// OTEL_TRACE_SAMPLER, unchanged behaviour.
+		{"legacy never", "0", "", "", "AlwaysOffSampler"},
+		{"legacy negative", "-1", "", "", "AlwaysOffSampler"},
+		{"legacy always", "1", "", "", "AlwaysOnSampler"},
+		{"legacy ratio", "0.1", "", "", "ParentBased{root:TraceIDRatioBased{0.1}"},
+		{"legacy invalid", "bogus", "", "", parentBasedAlwaysOn},
+
+		// OTEL_TRACE_SAMPLER wins when both are set.
+		{"legacy over standard", "0.1", "always_off", "", "ParentBased{root:TraceIDRatioBased{0.1}"},
+
+		// Standard values.
+		{"always_on", "", "always_on", "", "AlwaysOnSampler"},
+		{"always_off", "", "always_off", "", "AlwaysOffSampler"},
+		{"traceidratio", "", "traceidratio", "0.25", "TraceIDRatioBased{0.25}"},
+		{"parentbased_always_on", "", "parentbased_always_on", "", parentBasedAlwaysOn},
+		{"parentbased_always_off", "", "parentbased_always_off", "", "ParentBased{root:AlwaysOffSampler"},
+		{"parentbased_traceidratio", "", "parentbased_traceidratio", "0.1", "ParentBased{root:TraceIDRatioBased{0.1}"},
+
+		// Names are matched case-insensitively and trimmed.
+		{"uppercase", "", "PARENTBASED_TRACEIDRATIO", "0.1", "ParentBased{root:TraceIDRatioBased{0.1}"},
+		{"padded", "", "  always_off  ", "", "AlwaysOffSampler"},
+
+		// Samplers that are not linked into the agent fall back.
+		{"jaeger_remote", "", "jaeger_remote", "", parentBasedAlwaysOn},
+		{"unknown", "", "not_a_sampler", "", parentBasedAlwaysOn},
+
+		// An unusable ratio falls back to 1.0, which is AlwaysOn.
+		{"missing arg", "", "traceidratio", "", "AlwaysOnSampler"},
+		{"invalid arg", "", "traceidratio", "abc", "AlwaysOnSampler"},
+		{"arg above range", "", "traceidratio", "5", "AlwaysOnSampler"},
+		{"arg below range", "", "traceidratio", "-1", "AlwaysOnSampler"},
+		{"arg NaN", "", "traceidratio", "NaN", "AlwaysOnSampler"},
+		{"arg Inf", "", "traceidratio", "Inf", "AlwaysOnSampler"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(trace_sampler, tt.legacy)
+			t.Setenv(traces_sampler, tt.standard)
+			t.Setenv(traces_sampler_arg, tt.arg)
+
+			got := NewSpanSampler().Description()
+			if !strings.HasPrefix(got, tt.want) {
+				t.Errorf("NewSpanSampler() = %s, want it to start with %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseSamplerRatio(t *testing.T) {
+	tests := []struct {
+		arg  string
+		want float64
+	}{
+		{"0.1", 0.1},
+		{"0", 0},
+		{"1", 1},
+		{"  0.5  ", 0.5},
+		{"", default_sampler_ratio},
+		{"abc", default_sampler_ratio},
+		{"1.5", default_sampler_ratio},
+		{"-0.1", default_sampler_ratio},
+		// Every comparison against NaN is false, so a range check alone would
+		// let it reach the sampler.
+		{"NaN", default_sampler_ratio},
+		{"Inf", default_sampler_ratio},
+		{"-Inf", default_sampler_ratio},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.arg, func(t *testing.T) {
+			if got := parseSamplerRatio(tt.arg); got != tt.want {
+				t.Errorf("parseSamplerRatio(%q) = %v, want %v", tt.arg, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/sdkconfig/sampler_test.go
+++ b/pkg/sdkconfig/sampler_test.go
@@ -56,6 +56,8 @@ func TestNewSpanSampler(t *testing.T) {
 
 		// Samplers that are not linked into the agent fall back.
 		{"jaeger_remote", "", "jaeger_remote", "", parentBasedAlwaysOn},
+		{"parentbased_jaeger_remote", "", "parentbased_jaeger_remote", "", parentBasedAlwaysOn},
+		{"xray", "", "xray", "", parentBasedAlwaysOn},
 		{"unknown", "", "not_a_sampler", "", parentBasedAlwaysOn},
 
 		// An unusable ratio falls back to 1.0, which is AlwaysOn.
@@ -65,6 +67,14 @@ func TestNewSpanSampler(t *testing.T) {
 		{"arg below range", "", "traceidratio", "-1", "AlwaysOnSampler"},
 		{"arg NaN", "", "traceidratio", "NaN", "AlwaysOnSampler"},
 		{"arg Inf", "", "traceidratio", "Inf", "AlwaysOnSampler"},
+
+		// The same fallbacks reach the parent-based variant.
+		{"parentbased missing arg", "", "parentbased_traceidratio", "", parentBasedAlwaysOn},
+		{"parentbased invalid arg", "", "parentbased_traceidratio", "abc", parentBasedAlwaysOn},
+		{"parentbased arg above range", "", "parentbased_traceidratio", "5", parentBasedAlwaysOn},
+		{"parentbased arg below range", "", "parentbased_traceidratio", "-1", parentBasedAlwaysOn},
+		{"parentbased arg NaN", "", "parentbased_traceidratio", "NaN", parentBasedAlwaysOn},
+		{"parentbased arg Inf", "", "parentbased_traceidratio", "Inf", parentBasedAlwaysOn},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

The agent reads only `OTEL_TRACE_SAMPLER`, which is specific to this project. The standard SDK variables are ignored, so a deployment configured the standard way silently runs with the default sampler:

```bash
export OTEL_TRACES_SAMPLER=parentbased_traceidratio
export OTEL_TRACES_SAMPLER_ARG=0.1
```

The intent is 10% sampling; what actually happens is `ParentBased(AlwaysSample)` — every trace is sampled and exported. There is no warning, because from the agent's point of view nothing was configured at all.

This is easy to hit in practice: our observability platform injects the standard variables into every application it onboards, the same set the Java and Python SDKs consume. Nothing in the agent's behaviour hints that they are being dropped — you only notice when the trace volume is 10x the expectation.

It also doesn't match what the project already tells users. In #544 the answer was:

> general configurations such as sampling rate follow the OpenTelemetry SDK standard and can be set directly through the official OTel environment variables

That is exactly what this PR makes true.

## Change

Support `OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG` per the [SDK environment variable specification](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/):

| Value | Sampler |
| --- | --- |
| `always_on` / `always_off` | `AlwaysSample()` / `NeverSample()` |
| `traceidratio` | `TraceIDRatioBased(arg)` |
| `parentbased_always_on` (spec default) / `parentbased_always_off` | `ParentBased(...)` |
| `parentbased_traceidratio` | `ParentBased(TraceIDRatioBased(arg))` |

Matched case-insensitively. `jaeger_remote`, `parentbased_jaeger_remote` and `xray` require samplers that aren't linked into the agent, so they log and fall back to the default rather than failing startup. A missing, unparsable or out-of-range `OTEL_TRACES_SAMPLER_ARG` falls back to a ratio of `1.0`, as the spec requires.

## Backward compatibility

`OTEL_TRACE_SAMPLER` keeps precedence when set — deployments already using it are unaffected, and its parsing moved into `newRatioSampler` unchanged. When neither variable is set the sampler is exactly what it was before: `ParentBased(AlwaysSample)`, which happens to be the spec default `parentbased_always_on`.

Verified against the existing behaviour:

| `OTEL_TRACE_SAMPLER` | `OTEL_TRACES_SAMPLER` | `_ARG` | Resulting sampler |
| --- | --- | --- | --- |
| — | — | — | `ParentBased{root:AlwaysOn}` (unchanged) |
| `0` | — | — | `AlwaysOff` (unchanged) |
| `1` | — | — | `AlwaysOn` (unchanged) |
| `bogus` | — | — | logs, `ParentBased{root:AlwaysOn}` (unchanged) |
| `0.1` | `always_off` | — | `ParentBased{root:TraceIDRatioBased{0.1}}` — legacy wins |
| — | `parentbased_traceidratio` | `0.1` | `ParentBased{root:TraceIDRatioBased{0.1}}` |
| — | `PARENTBASED_TRACEIDRATIO` | `0.1` | same (case-insensitive) |
| — | `traceidratio` | `0.25` | `TraceIDRatioBased{0.25}` |
| — | `parentbased_traceidratio` | *(unset)* | ratio `1.0` |
| — | `parentbased_traceidratio` | `abc` / `5` | logs, ratio `1.0` |
| — | `jaeger_remote` | — | logs, `ParentBased{root:AlwaysOn}` |

## Question for maintainers: which variable should win?

I gave `OTEL_TRACE_SAMPLER` precedence so that existing deployments keep working untouched. The argument for the opposite order is that the standard variable is the one the project points users at (#544), and a project-specific shorthand overriding the standard configuration can be surprising.

Happy to flip it — it's swapping the two `if` blocks — or to make the agent log when both are set and one is being ignored. Let me know which you prefer.

## Testing

Behaviour was verified across the matrix above. I did not add a test file: `pkg` cannot be built by the standard toolchain outside the agent's own build (`trace.GetTestSpans`, `runtime.ExitHook` and friends are injected at compile time), which is presumably why the package currently has no `*_test.go`. If there's an established way to unit-test this package, I'm glad to add coverage.

Docs updated in `docs/user/sdk-config.md` and `docs/zh/user/sdk-config.md`.
