### PR TITLE
fix(fasthttp): guard clientFastHttpOnExit against missing call data

### DIFF
--- a/pkg/rules/fasthttp/fasthttp_client_setup.go
+++ b/pkg/rules/fasthttp/fasthttp_client_setup.go
@@ -60,8 +60,18 @@ func clientFastHttpOnExit(call api.CallContext, err error) {
 	if !fastHttpEnabler.Enable() {
 		return
 	}
-	data := call.GetData().(map[string]interface{})
-	ctx := data["ctx"].(context.Context)
+	dataRaw := call.GetData()
+	if dataRaw == nil {
+		return
+	}
+	data, ok := dataRaw.(map[string]interface{})
+	if !ok {
+		return
+	}
+	ctx, ok := data["ctx"].(context.Context)
+	if !ok {
+		return
+	}
 	request := data["request"].(fastHttpRequest)
 	resp := data["response"].(*fasthttp.Response)
 	fastHttpClientInstrumenter.End(ctx, request, fastHttpResponse{


### PR DESCRIPTION
## What

`clientFastHttpOnEnter` returns early when `url.Parse` fails on a malformed request URI, leaving no data on the call context. `clientFastHttpOnExit` then unconditionally type-asserts `call.GetData()` to `map[string]interface{}`, which panics and takes down the goroutine issuing the request.

```go
// OnEnter: early return without SetData
u, err := url.Parse(req.URI().String())
if err != nil {
    return
}
// OnExit: panics when data was never set
data := call.GetData().(map[string]interface{})
```

## How

Mirror the OnEnter early returns in OnExit with nil and comma-ok guards, following the same hardening applied to `langchain callChainOnExit` in #728.

## Testing

- `go build` / `go vet` on `pkg/rules/fasthttp`
- Instrumented muzzle-style build of `test/fasthttp/v1.45.0/test_basic_http.go` via `otel go build` passes
- Fasthttp plugin CI (`fasthttp`, `fasthttp-capture-*, latestdepth`) should keep passing; behavior is unchanged for well-formed request URIs

