### PR TITLE
fix(trpc): avoid panic on non-trpc server errors, fix statusCode typo

### DIFF
--- a/pkg/rules/trpc/trpc_client_setup.go
+++ b/pkg/rules/trpc/trpc_client_setup.go
@@ -73,7 +73,7 @@ func clientTrpcOnExit(call api.CallContext, err error) {
 		statusCode = int(request.msg.ServerRspErr().Code)
 	}
 	trpcClientInstrumenter.End(ctx, request, trpcRes{
-		stausCode: statusCode,
+		statusCode: statusCode,
 	}, err)
 }
 

--- a/pkg/rules/trpc/trpc_data_type.go
+++ b/pkg/rules/trpc/trpc_data_type.go
@@ -24,5 +24,5 @@ type trpcReq struct {
 }
 
 type trpcRes struct {
-	stausCode int
+	statusCode int
 }

--- a/pkg/rules/trpc/trpc_otel_instrumenter.go
+++ b/pkg/rules/trpc/trpc_otel_instrumenter.go
@@ -85,7 +85,7 @@ type trpcStatusCodeExtractor[REQUEST trpcReq, RESPONSE trpcRes] struct {
 }
 
 func (t trpcStatusCodeExtractor[REQUEST, RESPONSE]) Extract(span trace.Span, request trpcReq, response trpcRes, err error) {
-	statusCode := response.stausCode
+	statusCode := response.statusCode
 	if statusCode != 0 {
 		if err != nil {
 			span.RecordError(err)

--- a/pkg/rules/trpc/trpc_server_setup.go
+++ b/pkg/rules/trpc/trpc_server_setup.go
@@ -16,6 +16,7 @@ package trpc
 
 import (
 	"context"
+	"errors"
 	_ "unsafe"
 
 	"github.com/alibaba/loongsuite-go/pkg/api"
@@ -52,9 +53,12 @@ func serverTrpcOnExit(call api.CallContext, _ interface{}, err error) {
 	request := data["request"].(trpcReq)
 	statusCode := 0
 	if err != nil {
-		statusCode = int(err.(*errs.Error).Code)
+		var trpcErr *errs.Error
+		if errors.As(err, &trpcErr) {
+			statusCode = int(trpcErr.Code)
+		}
 	}
 	trpcServerInstrumenter.End(ctx, request, trpcRes{
-		stausCode: statusCode,
+		statusCode: statusCode,
 	}, err)
 }


### PR DESCRIPTION
## What

`serverTrpcOnExit` unconditionally asserts the handler error to `*errs.Error`:

```go
statusCode := 0
if err != nil {
    statusCode = int(err.(*errs.Error).Code)  // panics on non-trpc errors
}
```

trpc-go service implementations can return arbitrary errors (`errors.New`, `context.DeadlineExceeded`, `fmt.Errorf("%w", ...)` wrapped errors, ...). Any of those panics the OnExit hook and crashes the server goroutine.

## How

- Use `errors.As` so both direct and wrapped `*errs.Error` values are recognized; non-trpc errors now yield `statusCode = 0` and the span simply records the error instead of panicking. Same approach as the nacos rules (`pkg/rules/nacos/.../nacos_go_client_*_setup.go`).
- Rename the misspelled `trpcRes.stausCode` field to `statusCode` (4 occurrences, all within `pkg/rules/trpc`).

## Testing

- `go build` / `go vet` on `pkg/rules/trpc`
- Instrumented muzzle-style build of `test/trpc/v1.0.0/test_trpc_basic.go` via `otel go build` passes
- Span behavior for genuine trpc errors is unchanged (code still extracted and recorded)

