### PR TITLE
fix(sqlx): honor OTEL_INSTRUMENTATION_SQLX_ENABLED in query/exec hooks

### DIFF
--- a/pkg/rules/sqlx/setup.go
+++ b/pkg/rules/sqlx/setup.go
@@ -71,6 +71,9 @@ func afterConnect(ctx api.CallContext, db *sqlx.DB, err error) {
 
 //go:linkname beforeQueryx github.com/jmoiron/sqlx.beforeQueryx
 func beforeQueryx(ctx api.CallContext, db *sqlx.DB, query string, args ...interface{}) {
+	if !sqlxEnabler.Enable() {
+		return
+	}
 	request := sqlxRequest{
 		opType:     extractOpType(query),
 		statement:  query,
@@ -85,12 +88,18 @@ func beforeQueryx(ctx api.CallContext, db *sqlx.DB, query string, args ...interf
 
 //go:linkname afterQueryx github.com/jmoiron/sqlx.afterQueryx
 func afterQueryx(ctx api.CallContext, _ *sqlx.Rows, err error) {
+	if !sqlxEnabler.Enable() {
+		return
+	}
 	request := ctx.GetData().(sqlxRequest)
 	sqlInstrumenter.End(context.Background(), request, nil, err)
 }
 
 //go:linkname beforeQueryRowx github.com/jmoiron/sqlx.beforeQueryRowx
 func beforeQueryRowx(ctx api.CallContext, db *sqlx.DB, query string, args ...interface{}) {
+	if !sqlxEnabler.Enable() {
+		return
+	}
 	request := sqlxRequest{
 		opType:     extractOpType(query),
 		statement:  query,
@@ -105,12 +114,18 @@ func beforeQueryRowx(ctx api.CallContext, db *sqlx.DB, query string, args ...int
 
 //go:linkname afterQueryRowx github.com/jmoiron/sqlx.afterQueryRowx
 func afterQueryRowx(ctx api.CallContext, row *sqlx.Row) {
+	if !sqlxEnabler.Enable() {
+		return
+	}
 	request := ctx.GetData().(sqlxRequest)
 	sqlInstrumenter.End(context.Background(), request, nil, row.Err())
 }
 
 //go:linkname beforeNamedExec github.com/jmoiron/sqlx.beforeNamedExec
 func beforeNamedExec(ctx api.CallContext, db *sqlx.DB, query string, arg interface{}) {
+	if !sqlxEnabler.Enable() {
+		return
+	}
 	request := sqlxRequest{
 		opType:     extractOpType(query),
 		statement:  query,
@@ -125,12 +140,18 @@ func beforeNamedExec(ctx api.CallContext, db *sqlx.DB, query string, arg interfa
 
 //go:linkname afterNamedExec github.com/jmoiron/sqlx.afterNamedExec
 func afterNamedExec(ctx api.CallContext, _ sql.Result, err error) {
+	if !sqlxEnabler.Enable() {
+		return
+	}
 	request := ctx.GetData().(sqlxRequest)
 	sqlInstrumenter.End(context.Background(), request, nil, err)
 }
 
 //go:linkname beforeQueryxContext github.com/jmoiron/sqlx.beforeQueryxContext
 func beforeQueryxContext(ctx api.CallContext, db *sqlx.DB, _ context.Context, query string, args ...interface{}) {
+	if !sqlxEnabler.Enable() {
+		return
+	}
 	request := sqlxRequest{
 		opType:     extractOpType(query),
 		statement:  query,
@@ -145,12 +166,18 @@ func beforeQueryxContext(ctx api.CallContext, db *sqlx.DB, _ context.Context, qu
 
 //go:linkname afterQueryxContext github.com/jmoiron/sqlx.afterQueryxContext
 func afterQueryxContext(ctx api.CallContext, _ *sqlx.Rows, err error) {
+	if !sqlxEnabler.Enable() {
+		return
+	}
 	request := ctx.GetData().(sqlxRequest)
 	sqlInstrumenter.End(context.Background(), request, nil, err)
 }
 
 //go:linkname beforeQueryRowxContext github.com/jmoiron/sqlx.beforeQueryRowxContext
 func beforeQueryRowxContext(ctx api.CallContext, db *sqlx.DB, _ context.Context, query string, args ...interface{}) {
+	if !sqlxEnabler.Enable() {
+		return
+	}
 	request := sqlxRequest{
 		opType:     extractOpType(query),
 		statement:  query,
@@ -165,6 +192,9 @@ func beforeQueryRowxContext(ctx api.CallContext, db *sqlx.DB, _ context.Context,
 
 //go:linkname afterQueryRowxContext github.com/jmoiron/sqlx.afterQueryRowxContext
 func afterQueryRowxContext(ctx api.CallContext, row *sqlx.Row) {
+	if !sqlxEnabler.Enable() {
+		return
+	}
 	request := ctx.GetData().(sqlxRequest)
 	sqlInstrumenter.End(context.Background(), request, nil, row.Err())
 }


### PR DESCRIPTION
## What

`beforeConnect`/`afterConnect` consult `sqlxEnabler`, but the five query/exec hook pairs (`Queryx`, `QueryRowx`, `NamedExec` and their `Context` variants) never check it. Setting `OTEL_INSTRUMENTATION_SQLX_ENABLED=false` therefore has no effect — sqlx spans keep being emitted.

## How

Add the same enabler guard to all ten hooks. Both sides of each pair must be guarded: checking only the before hooks would leave the after hooks asserting (`ctx.GetData().(sqlxRequest)`) on call data that was never set.

## Testing

- Instrumented muzzle-style build of `test/sqlx/v1.4.0/test_sqlx_crud.go` via `otel go build` passes (this package only compiles after instrumentation, since it references fields injected into sqlx)
- With the guard in place and the env var set to `false`, all ten hooks return early before touching the instrumenter or call data
- `test_sqlx_crud` CI (which runs with the enabler on) is unaffected

