### PR TITLE
fix(nethttp): don't overwrite existing traceparent when propagating

### DIFF
--- a/pkg/rules/http/net_http_otel_instrumenter.go
+++ b/pkg/rules/http/net_http_otel_instrumenter.go
@@ -232,8 +232,24 @@ func BuildNetHttpClientOtelInstrumenter() *instrumenter.PropagatingToDownstreamI
 		if n.header == nil {
 			return nil
 		}
-		return propagation.HeaderCarrier(n.header)
+		return nonOverwritingCarrier{propagation.HeaderCarrier(n.header)}
 	}, otel.GetTextMapPropagator())
+}
+
+// nonOverwritingCarrier keeps propagation headers that are already present
+// on the outgoing request. Clients that sign requests and reuse them across
+// retries (aws-sdk-go SigV4) fold the current header value into the
+// signature, so overwriting traceparent/tracestate after re-signing
+// invalidates it (#742).
+type nonOverwritingCarrier struct {
+	propagation.TextMapCarrier
+}
+
+func (c nonOverwritingCarrier) Set(key, value string) {
+	if c.TextMapCarrier.Get(key) != "" {
+		return
+	}
+	c.TextMapCarrier.Set(key, value)
 }
 
 func BuildNetHttpServerOtelInstrumenter() *instrumenter.PropagatingFromUpstreamInstrumenter[*netHttpRequest, *netHttpResponse] {


### PR DESCRIPTION
Fixes #742

## What

aws-sdk-go (SigV4) signs a request, and on retry **re-signs the same `*http.Request`** — folding whatever headers are present at that moment into `SignedHeaders` (v1's `ignoredHeaders` covers `X-Amzn-Trace-Id` but not W3C `traceparent`). The net/http client instrumentation injects `traceparent` at `RoundTrip` time with an unconditional `Set`, so:

1. Attempt 1: sign (no traceparent yet) → `RoundTrip` injects T1 → 200
2. Server 503 SlowDown → SDK re-signs, now `traceparent=T1` is in `SignedHeaders`
3. `RoundTrip` overwrites the header with T2 (fresh span id)
4. Sent T2 ≠ signed T1 → signature verification fails → **403 AccessDenied**

## How

Wrap the client-side propagation carrier (`net_http_otel_instrumenter.go`) so propagation headers already present on the outgoing request are kept as-is:

- first attempt still injects a fresh `traceparent` (nothing has signed it yet) — behavior unchanged for all normal requests
- retries keep the value that was signed; the signature stays valid and retries remain attached to the same trace
- also matches the general contract "respect caller-provided propagation headers"

The dedicated aws-sdk-go rule (otelaws-style, propagating inside the SDK chain before signing) remains the preferred endgame and will be followed up separately.

## Reproduction (self-contained, no S3 / no docker)

Repro app: aws-sdk-go v1.55.8 `s3.GetObject` against a local mock server that returns exactly one `503 SlowDown` and records `traceparent` + whether it appears in `SignedHeaders` per attempt. This is precisely the issue's `signed_mismatch` condition, with the re-signed value observable as the value present at re-sign time.

| build | attempt 1 | attempt 2 | outcome |
|---|---|---|---|
| main (a2050e4) | tp=T1, unsigned | tp=**T2≠T1**, `traceparent` **in SignedHeaders** | sent ≠ signed → 403 on real S3 (**BUG**) |
| this PR | tp=T1, unsigned | tp=**T1**, `traceparent` in SignedHeaders | sent == signed → signature valid (**FIXED**) |

Raw output:

```
main:    ATTEMPT 1: traceparent="00-1ba9...-e387...-01" traceparent_in_signed_headers=false
         ATTEMPT 2: traceparent="00-1ada...-5e8d...-01" traceparent_in_signed_headers=true
         RESULT: BUG (traceparent overwritten after re-signing; sent value != signed value -> 403 on real S3)

this PR: ATTEMPT 1: traceparent="00-b080...-7ee0...-01" traceparent_in_signed_headers=false
         ATTEMPT 2: traceparent="00-b080...-7ee0...-01" traceparent_in_signed_headers=true
         RESULT: FIXED (traceparent stable across retry; sent value == signed value)
```

`traceparent_in_signed_headers=true` on attempt 2 is the empirical confirmation that the SDK signs the header, i.e. the overwrite is what breaks the signature.

## Testing

- `go build` / `go vet` on `pkg/rules/http`
- Instrumented build (`otel go build`) of the repro app and of `test/nethttp/test_http.go` + `http_server.go` pass
- Red/green runtime repro above (deterministic: one forced retry, no intermittence)
- Fresh-request propagation is unchanged (attempt 1 injects a new traceparent in both builds), so the nethttp CI suites (`nethttp-*`, `nethttp-latestdepth`) are unaffected

