### PR TITLE
feat(tool): warn when instrumentation upgrades pinned dependencies

### DIFF
--- a/tool/preprocess/preprocess.go
+++ b/tool/preprocess/preprocess.go
@@ -330,6 +330,10 @@ func Preprocess() error {
 			return err
 		}
 	}
+
+	// Report before postProcess restores the user's go.mod, while the final
+	// resolved versions are still on disk.
+	dp.warnDependencyUpgrades()
 	util.Log("Build completed successfully")
 	return nil
 }

--- a/tool/preprocess/update.go
+++ b/tool/preprocess/update.go
@@ -15,6 +15,7 @@
 package preprocess
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/alibaba/loongsuite-go/tool/rules"
 	"github.com/alibaba/loongsuite-go/tool/util"
 	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/semver"
 )
 
 const (
@@ -248,4 +250,57 @@ func (dp *DepProcessor) updateGoMod() error {
 		}
 	}
 	return nil
+}
+
+// warnDependencyUpgrades reports dependencies that the instrumentation graph
+// resolves to a higher version than the one pinned in the user's original
+// go.mod. The user's go.mod is restored after the build, but the binary is
+// still compiled against the upgraded versions, which can break projects that
+// depend on locked versions (#386, #387).
+func (dp *DepProcessor) warnDependencyUpgrades() {
+	backup, ok := dp.backups[dp.getGoModPath()]
+	if !ok {
+		return
+	}
+	orig, err := parseGoMod(backup)
+	if err != nil {
+		return
+	}
+	cur, err := parseGoMod(dp.getGoModPath())
+	if err != nil {
+		return
+	}
+	upgraded := func(from, to string) bool {
+		if !semver.IsValid(from) {
+			from = "v" + from // go directive versions carry no prefix
+		}
+		if !semver.IsValid(to) {
+			to = "v" + to
+		}
+		return semver.IsValid(from) && semver.IsValid(to) &&
+			semver.Compare(to, from) > 0
+	}
+	origVer := make(map[string]string, len(orig.Require))
+	for _, r := range orig.Require {
+		origVer[r.Mod.Path] = r.Mod.Version
+	}
+	lines := make([]string, 0, 4)
+	for _, r := range cur.Require {
+		if from, ok := origVer[r.Mod.Path]; ok && upgraded(from, r.Mod.Version) {
+			lines = append(lines, fmt.Sprintf("  %s %s -> %s", r.Mod.Path, from, r.Mod.Version))
+		}
+	}
+	if orig.Go != nil && cur.Go != nil && upgraded(orig.Go.Version, cur.Go.Version) {
+		lines = append(lines, fmt.Sprintf("  go directive %s -> %s", orig.Go.Version, cur.Go.Version))
+	}
+	if len(lines) == 0 {
+		return
+	}
+	fmt.Fprintln(os.Stderr, "WARNING: instrumentation resolves dependencies pinned in your go.mod to newer versions,")
+	fmt.Fprintln(os.Stderr, "the binary is built against them even though your go.mod is restored afterwards:")
+	for _, line := range lines {
+		fmt.Fprintln(os.Stderr, line)
+	}
+	fmt.Fprintln(os.Stderr, "If your project relies on the pinned versions, pin them with replace directives or")
+	fmt.Fprintln(os.Stderr, "exclude the rule via OTEL_INSTRUMENTATION_*_ENABLED=false (see issue #386).")
 }


### PR DESCRIPTION
Fixes #387 (first step agreed in #386)

## What

Adding the instrumentation module to the user's build can resolve dependencies the user had **pinned** to higher versions via MVS. Example from #386, reproduced on current main with the reporter's demo (grpc v1.61.0, no otel deps in the project): the instrumented binary is compiled against `google.golang.org/grpc v1.78.0` — and five more transitive pins plus the `go` directive are raised — while the user's `go.mod` is silently restored after the build. Version-locked projects then break at startup with nothing in the build output pointing at the cause.

## How

Per the direction agreed between the reporter and maintainers in #386 ("warn users of the risk in obvious places") and requested in #387:

- After the toolexec build completes (before `postProcess` restores the backups), diff the backed-up `go.mod` against the final resolved one.
- Print a prominent stderr warning listing every **pre-existing** requirement that was raised, plus a raised `go` directive. Newly added dependencies (the normal case) stay silent.
- Version comparison uses `golang.org/x/mod/semver`, handling both `v`-prefixed requirements and the bare `go` directive.

## Reproduction (reporter's demo, current main a2050e4)

```
$ git clone https://github.com/JaredTan95/grpc-hello && cd grpc-hello   # grpc v1.61.0
$ otel go build server.go
WARNING: instrumentation resolves dependencies pinned in your go.mod to newer versions,
the binary is built against them even though your go.mod is restored afterwards:
  google.golang.org/grpc v1.61.0 -> v1.78.0
  golang.org/x/net v0.35.0 -> v0.49.0
  golang.org/x/sys v0.30.0 -> v0.40.0
  golang.org/x/text v0.22.0 -> v0.33.0
  google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-... -> v0.0.0-20260128011058-...
  google.golang.org/protobuf v1.36.5 -> v1.36.11
  go directive 1.23.3 -> 1.24.0
If your project relies on the pinned versions, pin them with replace directives or
exclude the rule via OTEL_INSTRUMENTATION_*_ENABLED=false (see issue #386).
$ grep grpc go.mod    # restored
require google.golang.org/grpc v1.61.0
```

A stdlib-only app produces no warning (only new requirements appear). The user's `go.mod`/`go.sum` restoration behavior is unchanged.

## Follow-up (not in this PR)

Actually preventing the upgrades (respecting pinned versions in the module graph) needs a pinning mechanism in the dependency-rewrite phase — happy to explore it as a separate change once this visibility lands.

