### PR TITLE
test(sdkconfig): update sampler descriptions for OTel v1.45 breaking change

### DIFF
--- a/pkg/sdkconfig/sampler_test.go
+++ b/pkg/sdkconfig/sampler_test.go
@@ -22,6 +22,12 @@ import (
 func TestNewSpanSampler(t *testing.T) {
 	const parentBasedAlwaysOn = "ParentBased{root:AlwaysOnSampler"
 
+	// Since OTel v1.43 the trace-ratio sampler no longer substitutes
+	// AlwaysSample() for a ratio of 1, so the description is the
+	// spec-compliant one for the ratio instead.
+	const ratioOne = "TraceIDRatioBased{1}"
+	const parentBasedRatioOne = "ParentBased{root:" + ratioOne
+
 	tests := []struct {
 		name     string
 		legacy   string
@@ -60,21 +66,22 @@ func TestNewSpanSampler(t *testing.T) {
 		{"xray", "", "xray", "", parentBasedAlwaysOn},
 		{"unknown", "", "not_a_sampler", "", parentBasedAlwaysOn},
 
-		// An unusable ratio falls back to 1.0, which is AlwaysOn.
-		{"missing arg", "", "traceidratio", "", "AlwaysOnSampler"},
-		{"invalid arg", "", "traceidratio", "abc", "AlwaysOnSampler"},
-		{"arg above range", "", "traceidratio", "5", "AlwaysOnSampler"},
-		{"arg below range", "", "traceidratio", "-1", "AlwaysOnSampler"},
-		{"arg NaN", "", "traceidratio", "NaN", "AlwaysOnSampler"},
-		{"arg Inf", "", "traceidratio", "Inf", "AlwaysOnSampler"},
+		// An unusable ratio falls back to ratio 1.0, whose spec-compliant
+		// description is TraceIDRatioBased{1}.
+		{"missing arg", "", "traceidratio", "", ratioOne},
+		{"invalid arg", "", "traceidratio", "abc", ratioOne},
+		{"arg above range", "", "traceidratio", "5", ratioOne},
+		{"arg below range", "", "traceidratio", "-1", ratioOne},
+		{"arg NaN", "", "traceidratio", "NaN", ratioOne},
+		{"arg Inf", "", "traceidratio", "Inf", ratioOne},
 
 		// The same fallbacks reach the parent-based variant.
-		{"parentbased missing arg", "", "parentbased_traceidratio", "", parentBasedAlwaysOn},
-		{"parentbased invalid arg", "", "parentbased_traceidratio", "abc", parentBasedAlwaysOn},
-		{"parentbased arg above range", "", "parentbased_traceidratio", "5", parentBasedAlwaysOn},
-		{"parentbased arg below range", "", "parentbased_traceidratio", "-1", parentBasedAlwaysOn},
-		{"parentbased arg NaN", "", "parentbased_traceidratio", "NaN", parentBasedAlwaysOn},
-		{"parentbased arg Inf", "", "parentbased_traceidratio", "Inf", parentBasedAlwaysOn},
+		{"parentbased missing arg", "", "parentbased_traceidratio", "", parentBasedRatioOne},
+		{"parentbased invalid arg", "", "parentbased_traceidratio", "abc", parentBasedRatioOne},
+		{"parentbased arg above range", "", "parentbased_traceidratio", "5", parentBasedRatioOne},
+		{"parentbased arg below range", "", "parentbased_traceidratio", "-1", parentBasedRatioOne},
+		{"parentbased arg NaN", "", "parentbased_traceidratio", "NaN", parentBasedRatioOne},
+		{"parentbased arg Inf", "", "parentbased_traceidratio", "Inf", parentBasedRatioOne},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

The Basic workflow `build (1.24, ubuntu-latest)` job fails: 12 subtests of `TestNewSpanSampler` fail on description assertions. The failing cases are the `missing` / `invalid` / `out-of-range` / `NaN` / `Inf` sampler argument values (which fall back to the default ratio 1.0) and the corresponding `parentbased_*` variants.

## Root Cause

#747 bumped the OpenTelemetry dependencies to v1.45. Since OTel v1.43 (upstream open-telemetry/opentelemetry-go#8027), `trace.TraceIDRatioBased(1.0)` returns a spec-compliant sampler whose `Description()` is `TraceIDRatioBased{1}`, instead of falling back to `AlwaysSample()` whose description is `AlwaysOnSampler`.

The sampling behavior (always sample) is unchanged; only the description string changed.

## Fix

Test-only change: update the expected sampler descriptions in `pkg/sdkconfig/sampler_test.go`. No implementation changes.

## Verification

Ran in a `golang:1.25` container with otel sdk v1.45.0 (same dependency version as CI):

```bash
cd pkg && go test ./sdkconfig/... -count=1
```

All tests pass.
