### PR TITLE
fix(sarama): isolate sync producer state per goroutine

### DIFF
--- a/pkg/rules/ibm-sarama/sarama_producer_setup.go
+++ b/pkg/rules/ibm-sarama/sarama_producer_setup.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	_ "unsafe"
 
 	"github.com/IBM/sarama"
@@ -30,14 +29,12 @@ import (
 
 const producerContextCacheMax = 16384
 
-var inSyncMode atomic.Bool
-
 //go:linkname newAsyncProducerOnEnter github.com/IBM/sarama.newAsyncProducerOnEnter
 func newAsyncProducerOnEnter(call api.CallContext, client sarama.Client) {
 	if !saramaEnabler.Enable() {
 		return
 	}
-	if inSyncMode.Load() {
+	if syncProducerCallDepthActive() {
 		return
 	}
 	data := make(map[string]interface{}, 1)
@@ -50,7 +47,7 @@ func newAsyncProducerOnExit(call api.CallContext, p sarama.AsyncProducer, err er
 	if !saramaEnabler.Enable() {
 		return
 	}
-	if inSyncMode.Load() {
+	if syncProducerCallDepthActive() {
 		return
 	}
 	if err != nil || call.GetData() == nil {
@@ -217,7 +214,7 @@ func newSyncProducerOnEnter(call api.CallContext, addrs []string, config *sarama
 	if !saramaEnabler.Enable() {
 		return
 	}
-	inSyncMode.Store(true)
+	syncProducerCallDepthEnter()
 	data := make(map[string]interface{}, 1)
 	data["saramaConfig"] = config
 	call.SetData(data)
@@ -225,10 +222,13 @@ func newSyncProducerOnEnter(call api.CallContext, addrs []string, config *sarama
 
 //go:linkname newSyncProducerOnExit github.com/IBM/sarama.newSyncProducerOnExit
 func newSyncProducerOnExit(call api.CallContext, producer sarama.SyncProducer, err error) {
-	if !saramaEnabler.Enable() || call.GetData() == nil {
+	if call.GetData() == nil {
 		return
 	}
-	defer inSyncMode.Store(false)
+	defer syncProducerCallDepthExit()
+	if !saramaEnabler.Enable() {
+		return
+	}
 	if err != nil {
 		return
 	}
@@ -256,7 +256,7 @@ func newSyncProducerFromClientOnEnter(call api.CallContext, client sarama.Client
 	if !saramaEnabler.Enable() {
 		return
 	}
-	inSyncMode.Store(true)
+	syncProducerCallDepthEnter()
 	data := make(map[string]interface{}, 1)
 	data["saramaConfig"] = client.Config()
 	call.SetData(data)
@@ -264,10 +264,13 @@ func newSyncProducerFromClientOnEnter(call api.CallContext, client sarama.Client
 
 //go:linkname newSyncProducerFromClientOnExit github.com/IBM/sarama.newSyncProducerFromClientOnExit
 func newSyncProducerFromClientOnExit(call api.CallContext, producer sarama.SyncProducer, err error) {
-	if !saramaEnabler.Enable() || call.GetData() == nil {
+	if call.GetData() == nil {
 		return
 	}
-	defer inSyncMode.Store(false)
+	defer syncProducerCallDepthExit()
+	if !saramaEnabler.Enable() {
+		return
+	}
 	if err != nil {
 		return
 	}

--- a/pkg/rules/ibm-sarama/sync_producer_depth.go
+++ b/pkg/rules/ibm-sarama/sync_producer_depth.go
@@ -1,0 +1,28 @@
+//go:build ignore
+
+// Copyright (c) 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sarama
+
+import _ "unsafe"
+
+//go:linkname syncProducerCallDepthEnter otel_sync_producer_call_depth_enter
+var syncProducerCallDepthEnter func()
+
+//go:linkname syncProducerCallDepthExit otel_sync_producer_call_depth_exit
+var syncProducerCallDepthExit func()
+
+//go:linkname syncProducerCallDepthActive otel_sync_producer_call_depth_active
+var syncProducerCallDepthActive func() bool

--- a/pkg/rules/ibm-sarama/sync_producer_depth.go
+++ b/pkg/rules/ibm-sarama/sync_producer_depth.go
@@ -1,5 +1,3 @@
-//go:build ignore
-
 // Copyright (c) 2026 Alibaba Group Holding Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/rules/runtime/runtime_linker.go
+++ b/pkg/rules/runtime/runtime_linker.go
@@ -36,6 +36,15 @@ var otel_set_trace_context_to_gls = _otel_gls_set_trace_context_impl
 //go:linkname otel_set_baggage_container_to_gls otel_set_baggage_container_to_gls
 var otel_set_baggage_container_to_gls = _otel_gls_set_baggage_container_impl
 
+//go:linkname otel_sync_producer_call_depth_enter otel_sync_producer_call_depth_enter
+var otel_sync_producer_call_depth_enter = _otel_sync_producer_call_depth_enter_impl
+
+//go:linkname otel_sync_producer_call_depth_exit otel_sync_producer_call_depth_exit
+var otel_sync_producer_call_depth_exit = _otel_sync_producer_call_depth_exit_impl
+
+//go:linkname otel_sync_producer_call_depth_active otel_sync_producer_call_depth_active
+var otel_sync_producer_call_depth_active = _otel_sync_producer_call_depth_active_impl
+
 //go:nosplit
 func _otel_gls_get_trace_context_impl() interface{} {
 	return getg().m.curg.otel_trace_context
@@ -54,6 +63,21 @@ func _otel_gls_set_trace_context_impl(v interface{}) {
 //go:nosplit
 func _otel_gls_set_baggage_container_impl(v interface{}) {
 	getg().m.curg.otel_baggage_container = v
+}
+
+//go:nosplit
+func _otel_sync_producer_call_depth_enter_impl() {
+	getg().m.curg.otel_sync_producer_call_depth++
+}
+
+//go:nosplit
+func _otel_sync_producer_call_depth_exit_impl() {
+	getg().m.curg.otel_sync_producer_call_depth--
+}
+
+//go:nosplit
+func _otel_sync_producer_call_depth_active_impl() bool {
+	return getg().m.curg.otel_sync_producer_call_depth > 0
 }
 
 type ContextSnapshoter interface {

--- a/pkg/rules/shopify-sarama/sarama_producer_setup.go
+++ b/pkg/rules/shopify-sarama/sarama_producer_setup.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	_ "unsafe"
 
 	"github.com/Shopify/sarama"
@@ -30,14 +29,12 @@ import (
 
 const producerContextCacheMax = 16384
 
-var inSyncMode atomic.Bool
-
 //go:linkname newAsyncProducerOnEnter github.com/Shopify/sarama.newAsyncProducerOnEnter
 func newAsyncProducerOnEnter(call api.CallContext, client sarama.Client) {
 	if !saramaEnabler.Enable() {
 		return
 	}
-	if inSyncMode.Load() {
+	if syncProducerCallDepthActive() {
 		return
 	}
 	data := make(map[string]interface{}, 1)
@@ -50,7 +47,7 @@ func newAsyncProducerOnExit(call api.CallContext, p sarama.AsyncProducer, err er
 	if !saramaEnabler.Enable() {
 		return
 	}
-	if inSyncMode.Load() {
+	if syncProducerCallDepthActive() {
 		return
 	}
 	if err != nil || call.GetData() == nil {
@@ -217,7 +214,7 @@ func newSyncProducerOnEnter(call api.CallContext, addrs []string, config *sarama
 	if !saramaEnabler.Enable() {
 		return
 	}
-	inSyncMode.Store(true)
+	syncProducerCallDepthEnter()
 	data := make(map[string]interface{}, 1)
 	data["saramaConfig"] = config
 	call.SetData(data)
@@ -225,10 +222,13 @@ func newSyncProducerOnEnter(call api.CallContext, addrs []string, config *sarama
 
 //go:linkname newSyncProducerOnExit github.com/Shopify/sarama.newSyncProducerOnExit
 func newSyncProducerOnExit(call api.CallContext, producer sarama.SyncProducer, err error) {
-	if !saramaEnabler.Enable() || call.GetData() == nil {
+	if call.GetData() == nil {
 		return
 	}
-	defer inSyncMode.Store(false)
+	defer syncProducerCallDepthExit()
+	if !saramaEnabler.Enable() {
+		return
+	}
 	if err != nil {
 		return
 	}
@@ -256,7 +256,7 @@ func newSyncProducerFromClientOnEnter(call api.CallContext, client sarama.Client
 	if !saramaEnabler.Enable() {
 		return
 	}
-	inSyncMode.Store(true)
+	syncProducerCallDepthEnter()
 	data := make(map[string]interface{}, 1)
 	data["saramaConfig"] = client.Config()
 	call.SetData(data)
@@ -264,10 +264,13 @@ func newSyncProducerFromClientOnEnter(call api.CallContext, client sarama.Client
 
 //go:linkname newSyncProducerFromClientOnExit github.com/Shopify/sarama.newSyncProducerFromClientOnExit
 func newSyncProducerFromClientOnExit(call api.CallContext, producer sarama.SyncProducer, err error) {
-	if !saramaEnabler.Enable() || call.GetData() == nil {
+	if call.GetData() == nil {
 		return
 	}
-	defer inSyncMode.Store(false)
+	defer syncProducerCallDepthExit()
+	if !saramaEnabler.Enable() {
+		return
+	}
 	if err != nil {
 		return
 	}

--- a/pkg/rules/shopify-sarama/sync_producer_depth.go
+++ b/pkg/rules/shopify-sarama/sync_producer_depth.go
@@ -1,0 +1,28 @@
+//go:build ignore
+
+// Copyright (c) 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sarama
+
+import _ "unsafe"
+
+//go:linkname syncProducerCallDepthEnter otel_sync_producer_call_depth_enter
+var syncProducerCallDepthEnter func()
+
+//go:linkname syncProducerCallDepthExit otel_sync_producer_call_depth_exit
+var syncProducerCallDepthExit func()
+
+//go:linkname syncProducerCallDepthActive otel_sync_producer_call_depth_active
+var syncProducerCallDepthActive func() bool

--- a/pkg/rules/shopify-sarama/sync_producer_depth.go
+++ b/pkg/rules/shopify-sarama/sync_producer_depth.go
@@ -1,5 +1,3 @@
-//go:build ignore
-
 // Copyright (c) 2026 Alibaba Group Holding Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/ibm-sarama/v1.40.0/test_concurrent_sync_producer.go
+++ b/test/ibm-sarama/v1.40.0/test_concurrent_sync_producer.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "sync"
+
+func main() {
+	const producerCount = 16
+
+	var wg sync.WaitGroup
+	wg.Add(producerCount)
+	for range producerCount {
+		go func() {
+			defer wg.Done()
+			producer, err := createSyncProducer()
+			if err != nil {
+				panic(err)
+			}
+			if err := producer.Close(); err != nil {
+				panic(err)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/test/ibm_sarama_tests.go
+++ b/test/ibm_sarama_tests.go
@@ -26,7 +26,17 @@ func init() {
 		NewGeneralTestCase("ibm-sarama-basic-test", ibmSaramaModuleName, "1.40.0", "", "1.22.0", "", TestIbmSaramaBasic),
 		NewGeneralTestCase("ibm-sarama-async-produce-test", ibmSaramaModuleName, "1.40.0", "", "1.22.0", "", TestIbmSaramaAsyncProduce),
 		NewGeneralTestCase("ibm-sarama-sync-batch-produce-test", ibmSaramaModuleName, "1.40.0", "", "1.22.0", "", TestIbmSaramaSyncBatchProduce),
+		NewGeneralTestCase("ibm-sarama-concurrent-sync-producer-test", ibmSaramaModuleName, "1.40.0", "", "1.22.0", "", TestIbmSaramaConcurrentSyncProducer),
 	)
+}
+
+func TestIbmSaramaConcurrentSyncProducer(t *testing.T, env ...string) {
+	containers := initKafkaContainer(t)
+	defer containers.CleanupContainers(context.Background())
+	UseApp("ibm-sarama/v1.40.0")
+	RunGoBuild(t, "go", "build", "test_concurrent_sync_producer.go", "base.go")
+	env = append(env, "KAFKA_ADDR="+containers.KafkaAddress)
+	RunApp(t, "test_concurrent_sync_producer", env...)
 }
 
 func TestIbmSaramaBasic(t *testing.T, env ...string) {

--- a/test/shopify-sarama/v1.22.0/test_concurrent_sync_producer.go
+++ b/test/shopify-sarama/v1.22.0/test_concurrent_sync_producer.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "sync"
+
+func main() {
+	const producerCount = 16
+
+	var wg sync.WaitGroup
+	wg.Add(producerCount)
+	for range producerCount {
+		go func() {
+			defer wg.Done()
+			producer, err := createSyncProducer()
+			if err != nil {
+				panic(err)
+			}
+			if err := producer.Close(); err != nil {
+				panic(err)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/test/shopify_sarama_tests.go
+++ b/test/shopify_sarama_tests.go
@@ -26,7 +26,17 @@ func init() {
 		NewGeneralTestCase("shopify-sarama-basic-test", shopifySaramaModuleName, "1.22.0", "", "1.22.0", "", TestShopifySaramaBasic),
 		NewGeneralTestCase("shopify-sarama-async-produce-test", shopifySaramaModuleName, "1.22.0", "", "1.22.0", "", TestShopifySaramaAsyncProduce),
 		NewGeneralTestCase("shopify-sarama-sync-batch-produce-test", shopifySaramaModuleName, "1.22.0", "", "1.22.0", "", TestShopifySaramaSyncBatchProduce),
+		NewGeneralTestCase("shopify-sarama-concurrent-sync-producer-test", shopifySaramaModuleName, "1.22.0", "", "1.22.0", "", TestShopifySaramaConcurrentSyncProducer),
 	)
+}
+
+func TestShopifySaramaConcurrentSyncProducer(t *testing.T, env ...string) {
+	containers := initKafkaContainer(t)
+	defer containers.CleanupContainers(context.Background())
+	UseApp("shopify-sarama/v1.22.0")
+	RunGoBuild(t, "go", "build", "test_concurrent_sync_producer.go", "base.go")
+	env = append(env, "KAFKA_ADDR="+containers.KafkaAddress)
+	RunApp(t, "test_concurrent_sync_producer", env...)
 }
 
 func TestShopifySaramaBasic(t *testing.T, env ...string) {

--- a/tool/data/rules/base.json
+++ b/tool/data/rules/base.json
@@ -13,6 +13,12 @@
   },
   {
     "ImportPath": "runtime",
+    "StructType": "g",
+    "FieldName": "otel_sync_producer_call_depth",
+    "FieldType": "int32"
+  },
+  {
+    "ImportPath": "runtime",
     "Function": "newproc1",
     "OnEnter": "defer func(){ retVal0.otel_trace_context = contextPropagate(callergp.otel_trace_context); retVal0.otel_baggage_container = contextPropagate(callergp.otel_baggage_container); }()",
     "UseRaw": true


### PR DESCRIPTION
Fixes #755

## Summary

- replace the process-wide Sarama `inSyncMode` boolean with a nesting depth stored on the current runtime goroutine
- expose enter, exit, and active operations through the existing runtime linker pattern
- apply the same fix to IBM and Shopify Sarama instrumentation
- add concurrent constructor and publish-span coverage for both supported Sarama variants, including `NewSyncProducerFromClient` and panic recovery

The old global flag can be cleared by one goroutine while another is still inside `NewSyncProducer`. Its internal async producer is then wrapped and Sarama's unexported `*asyncProducer` assertion panics. A goroutine-local depth keeps the skip decision scoped to the synchronous constructor call stack without suppressing unrelated async producers.

## Upgrade behavior

Async producers created on other goroutines during synchronous producer construction are now instrumented instead of silently skipped. Applications that construct producers concurrently may therefore see more publish spans after upgrading; those spans were previously missing.

## Validation

- `go test ./tool/config ./tool/preprocess`
- `make build`
- `go test ./test -run '^TestBuildProject$' -count=1`
- `gofmt -d` on all changed Go files
- `git diff --check`

The focused instrumented build validates the runtime field injection, linker symbols, packaged rules, and generated application together.

Review follow-up validation on Windows / Go 1.25.0:

- `go test ./tool/config ./tool/preprocess` passes.
- Both updated concurrent test applications compile with instrumentation and pass against a local Sarama MockBroker, each asserting 19 publish traces.
- The tests cover both sync constructors, an async producer created while another goroutine is deterministically held inside a sync constructor, and async instrumentation after a nil-client panic.
- A separate instrumented smoke program passes depth isolation, nesting, and nil-client recovery checks.
- `gofmt` and `git diff --check` pass. The container-backed Kafka CI cases still need to run.

## AI assistance

Codex assisted with root-cause analysis, implementation, and regression test design. I reviewed the complete diff and take responsibility for the change.
