### PR TITLE
chore: bump otel/log to v0.21.0 and migrate util-genai to the attribute.KeyValue API

### DIFF
--- a/example/genai-demo/genai-observability/go.mod
+++ b/example/genai-demo/genai-observability/go.mod
@@ -5,10 +5,10 @@ go 1.25.0
 require (
 	github.com/alibaba/loongsuite-go/util-genai v0.0.0-00010101000000-000000000000
 	go.opentelemetry.io/otel v1.45.0
-	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.16.0
+	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.21.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
-	go.opentelemetry.io/otel/sdk/log v0.16.0
+	go.opentelemetry.io/otel/sdk/log v0.21.0
 )
 
 require (
@@ -17,7 +17,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/log v0.16.0 // indirect
+	go.opentelemetry.io/otel/log v0.21.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect
 	go.opentelemetry.io/otel/trace v1.45.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/example/genai-demo/genai-stream/go.mod
+++ b/example/genai-demo/genai-stream/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/log v0.16.0 // indirect
+	go.opentelemetry.io/otel/log v0.21.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect
 	go.opentelemetry.io/otel/trace v1.45.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/example/genai-demo/genai-tool/go.mod
+++ b/example/genai-demo/genai-tool/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/log v0.16.0 // indirect
+	go.opentelemetry.io/otel/log v0.21.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect
 	go.opentelemetry.io/otel/trace v1.45.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/example/genai-demo/genai/go.mod
+++ b/example/genai-demo/genai/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/log v0.16.0 // indirect
+	go.opentelemetry.io/otel/log v0.21.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect
 	go.opentelemetry.io/otel/trace v1.45.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/util-genai/events.go
+++ b/util-genai/events.go
@@ -108,55 +108,7 @@ func emitEvent(ctx context.Context, logger log.Logger, eventName string, attrs [
 	var record log.Record
 	record.SetTimestamp(time.Now())
 	record.SetEventName(eventName)
-	record.AddAttributes(attrsToLogKeyValues(attrs)...)
+	record.AddAttributes(attrs...)
 
 	logger.Emit(ctx, record)
-}
-
-// attrsToLogKeyValues converts trace attribute.KeyValue values into log
-// key-values so the same attribute builders can feed both spans and events.
-func attrsToLogKeyValues(attrs []attribute.KeyValue) []log.KeyValue {
-	out := make([]log.KeyValue, 0, len(attrs))
-	for _, kv := range attrs {
-		key := string(kv.Key)
-		switch kv.Value.Type() {
-		case attribute.BOOL:
-			out = append(out, log.Bool(key, kv.Value.AsBool()))
-		case attribute.INT64:
-			out = append(out, log.Int64(key, kv.Value.AsInt64()))
-		case attribute.FLOAT64:
-			out = append(out, log.Float64(key, kv.Value.AsFloat64()))
-		case attribute.STRING:
-			out = append(out, log.String(key, kv.Value.AsString()))
-		case attribute.BOOLSLICE:
-			vals := kv.Value.AsBoolSlice()
-			lv := make([]log.Value, len(vals))
-			for i, v := range vals {
-				lv[i] = log.BoolValue(v)
-			}
-			out = append(out, log.Slice(key, lv...))
-		case attribute.INT64SLICE:
-			vals := kv.Value.AsInt64Slice()
-			lv := make([]log.Value, len(vals))
-			for i, v := range vals {
-				lv[i] = log.Int64Value(v)
-			}
-			out = append(out, log.Slice(key, lv...))
-		case attribute.FLOAT64SLICE:
-			vals := kv.Value.AsFloat64Slice()
-			lv := make([]log.Value, len(vals))
-			for i, v := range vals {
-				lv[i] = log.Float64Value(v)
-			}
-			out = append(out, log.Slice(key, lv...))
-		case attribute.STRINGSLICE:
-			vals := kv.Value.AsStringSlice()
-			lv := make([]log.Value, len(vals))
-			for i, v := range vals {
-				lv[i] = log.StringValue(v)
-			}
-			out = append(out, log.Slice(key, lv...))
-		}
-	}
-	return out
 }

--- a/util-genai/events_test.go
+++ b/util-genai/events_test.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"testing"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/log/embedded"
 )
@@ -59,8 +60,8 @@ func (p *recordingLoggerProvider) Logger(string, ...log.LoggerOption) log.Logger
 // attrMap flattens a record's attributes into a key -> string-value map.
 func attrMap(r log.Record) map[string]string {
 	m := make(map[string]string)
-	r.WalkAttributes(func(kv log.KeyValue) bool {
-		m[kv.Key] = kv.Value.AsString()
+	r.WalkAttributes(func(kv attribute.KeyValue) bool {
+		m[string(kv.Key)] = kv.Value.AsString()
 		return true
 	})
 	return m

--- a/util-genai/go.mod
+++ b/util-genai/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	go.opentelemetry.io/otel v1.45.0
-	go.opentelemetry.io/otel/log v0.16.0
+	go.opentelemetry.io/otel/log v0.21.0
 	go.opentelemetry.io/otel/metric v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0
 )

--- a/util-genai/integration/go.mod
+++ b/util-genai/integration/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/alibaba/loongsuite-go/util-genai v0.0.0-00010101000000-000000000000
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
-	go.opentelemetry.io/otel/sdk/log v0.16.0
+	go.opentelemetry.io/otel/sdk/log v0.21.0
 	go.opentelemetry.io/otel/sdk/metric v1.45.0
 )
 
@@ -18,7 +18,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/log v0.16.0 // indirect
+	go.opentelemetry.io/otel/log v0.21.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect
 	go.opentelemetry.io/otel/trace v1.45.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect


### PR DESCRIPTION
## Summary

Picks up the `otel/log` bump that #747 deferred, and migrates `util-genai` to the API that replaced the removed one.

| Module | Before | After |
| --- | --- | --- |
| `otel/log` | v0.16.0 | **v0.21.0** |
| `otel/sdk/log` | v0.16.0 | **v0.21.0** |
| `otel/exporters/stdout/stdoutlog` | v0.16.0 | **v0.21.0** |

## Why v0.21.0 and not v0.22.0

v0.21.0 is the log release paired with `otel` v1.45.0, which the tree pins today. v0.22.0 requires `otel` v1.46.0 and would drag every module with it, so it belongs to whenever the tree moves to v1.46 rather than here.

## The API break #747 hit

v0.21.0 removes `keyvalue.go`. Log records now carry `attribute.KeyValue` and `attribute.Value` directly instead of the parallel `log.KeyValue` / `log.Value` types:

```go
// v0.16.0
func (r *Record) AddAttributes(attrs ...log.KeyValue)
func (r *Record) WalkAttributes(f func(log.KeyValue) bool)

// v0.21.0
func (r *Record) AddAttributes(attrs ...attribute.KeyValue)
func (r *Record) WalkAttributes(f func(attribute.KeyValue) bool)
```

`util-genai/events.go` was the only consumer in the repo, which is why the bump and the migration land together.

## What that removes

`emitEvent` already receives `[]attribute.KeyValue`, so `attrsToLogKeyValues` existed purely to copy each attribute into its log-typed twin — a 45-line type switch over eight attribute kinds, four of which rebuilt slices element by element. `Record.AddAttributes` now takes those values as-is, so the whole function goes:

```go
-	record.AddAttributes(attrsToLogKeyValues(attrs)...)
+	record.AddAttributes(attrs...)
```

That also drops a silent-loss path. The old switch handled the eight valid attribute types and discarded anything else, so an `attribute.INVALID` value vanished without a trace instead of reaching the SDK.

`events_test.go`'s `attrMap` helper walks with the new signature; nothing else in the test file changes, and the assertions are untouched.

## Scope

**Included:** `util-genai`, `util-genai/integration`, and the four `genai-demo` examples. The examples resolve `util-genai` through a `replace` to the local directory, so leaving them on v0.16.0 would pin a version their own dependency contradicts.

**Excluded:** `test/adk-go/v0.6.0` keeps v0.16.0. It arrives transitively from `google.golang.org/adk`, not from `util-genai`, and is a compatibility fixture rather than a shipped module.

`otelDeps` in `tool/preprocess/update.go` needs no change — it never carried `otel/log`.

## Testing

Green under Go 1.25.13:

```
util-genai              go build / go vet / go test -race    ok
util-genai/integration  go build / go vet / go test -race    ok
genai-demo (all four)   go build                             ok
```
