### PR TITLE
chore: bump sonic and pid to unblock Go 1.26, add 1.26 to CI

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -34,14 +34,17 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
-        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
-        # !go1.26, which broke the eino and hertz builds.
+        # path that users on 1.24 rely on. Go 1.26 and 1.27 joined once
+        # bytedance/sonic reached v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds. sonic keeps its
+        # assembly fast paths behind !go1.28, so 1.27 exercises the same code
+        # as 1.26 and the next toolchain is the one to re-check.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
           - 1.26
+          - 1.27
         os:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -34,13 +34,14 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 is held back until
-        # bytedance/sonic >= v1.15.0 is picked up - v1.14.1 gates GoMapIterator
-        # behind !go1.26, which breaks the eino and hertz builds.
+        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
+        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
+          - 1.26
         os:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -30,6 +30,9 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      # One flaky Go version should not cancel the others; the matrix is
+      # wide enough now that a cancelled column hides real signal.
+      fail-fast: false
       # If you want to matrix build , you can append the following list.
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -34,17 +34,14 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 and 1.27 joined once
-        # bytedance/sonic reached v1.15.x - v1.14.1 gated GoMapIterator behind
-        # !go1.26, which broke the eino and hertz builds. sonic keeps its
-        # assembly fast paths behind !go1.28, so 1.27 exercises the same code
-        # as 1.26 and the next toolchain is the one to re-check.
+        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
+        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
           - 1.26
-          - 1.27
         os:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/latestdepth1.yml
+++ b/.github/workflows/latestdepth1.yml
@@ -27,13 +27,14 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 is held back until
-        # bytedance/sonic >= v1.15.0 is picked up - v1.14.1 gates GoMapIterator
-        # behind !go1.26, which breaks the eino and hertz builds.
+        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
+        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
+          - 1.26
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/latestdepth1.yml
+++ b/.github/workflows/latestdepth1.yml
@@ -27,17 +27,14 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 and 1.27 joined once
-        # bytedance/sonic reached v1.15.x - v1.14.1 gated GoMapIterator behind
-        # !go1.26, which broke the eino and hertz builds. sonic keeps its
-        # assembly fast paths behind !go1.28, so 1.27 exercises the same code
-        # as 1.26 and the next toolchain is the one to re-check.
+        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
+        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
           - 1.26
-          - 1.27
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/latestdepth1.yml
+++ b/.github/workflows/latestdepth1.yml
@@ -24,6 +24,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      # One flaky Go version should not cancel the others; the matrix is
+      # wide enough now that a cancelled column hides real signal.
+      fail-fast: false
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade

--- a/.github/workflows/latestdepth1.yml
+++ b/.github/workflows/latestdepth1.yml
@@ -27,14 +27,17 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
-        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
-        # !go1.26, which broke the eino and hertz builds.
+        # path that users on 1.24 rely on. Go 1.26 and 1.27 joined once
+        # bytedance/sonic reached v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds. sonic keeps its
+        # assembly fast paths behind !go1.28, so 1.27 exercises the same code
+        # as 1.26 and the next toolchain is the one to re-check.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
           - 1.26
+          - 1.27
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/latestdepth2.yml
+++ b/.github/workflows/latestdepth2.yml
@@ -27,13 +27,14 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 is held back until
-        # bytedance/sonic >= v1.15.0 is picked up - v1.14.1 gates GoMapIterator
-        # behind !go1.26, which breaks the eino and hertz builds.
+        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
+        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
+          - 1.26
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/latestdepth2.yml
+++ b/.github/workflows/latestdepth2.yml
@@ -27,17 +27,14 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 and 1.27 joined once
-        # bytedance/sonic reached v1.15.x - v1.14.1 gated GoMapIterator behind
-        # !go1.26, which broke the eino and hertz builds. sonic keeps its
-        # assembly fast paths behind !go1.28, so 1.27 exercises the same code
-        # as 1.26 and the next toolchain is the one to re-check.
+        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
+        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
           - 1.26
-          - 1.27
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/latestdepth2.yml
+++ b/.github/workflows/latestdepth2.yml
@@ -24,6 +24,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      # One flaky Go version should not cancel the others; the matrix is
+      # wide enough now that a cancelled column hides real signal.
+      fail-fast: false
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade

--- a/.github/workflows/latestdepth2.yml
+++ b/.github/workflows/latestdepth2.yml
@@ -27,14 +27,17 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
-        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
-        # !go1.26, which broke the eino and hertz builds.
+        # path that users on 1.24 rely on. Go 1.26 and 1.27 joined once
+        # bytedance/sonic reached v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds. sonic keeps its
+        # assembly fast paths behind !go1.28, so 1.27 exercises the same code
+        # as 1.26 and the next toolchain is the one to re-check.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
           - 1.26
+          - 1.27
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/latestdepth3.yml
+++ b/.github/workflows/latestdepth3.yml
@@ -27,13 +27,14 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 is held back until
-        # bytedance/sonic >= v1.15.0 is picked up - v1.14.1 gates GoMapIterator
-        # behind !go1.26, which breaks the eino and hertz builds.
+        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
+        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
+          - 1.26
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/latestdepth3.yml
+++ b/.github/workflows/latestdepth3.yml
@@ -27,17 +27,14 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 and 1.27 joined once
-        # bytedance/sonic reached v1.15.x - v1.14.1 gated GoMapIterator behind
-        # !go1.26, which broke the eino and hertz builds. sonic keeps its
-        # assembly fast paths behind !go1.28, so 1.27 exercises the same code
-        # as 1.26 and the next toolchain is the one to re-check.
+        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
+        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
           - 1.26
-          - 1.27
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/latestdepth3.yml
+++ b/.github/workflows/latestdepth3.yml
@@ -24,6 +24,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      # One flaky Go version should not cancel the others; the matrix is
+      # wide enough now that a cancelled column hides real signal.
+      fail-fast: false
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade

--- a/.github/workflows/latestdepth3.yml
+++ b/.github/workflows/latestdepth3.yml
@@ -27,14 +27,17 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
-        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
-        # !go1.26, which broke the eino and hertz builds.
+        # path that users on 1.24 rely on. Go 1.26 and 1.27 joined once
+        # bytedance/sonic reached v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds. sonic keeps its
+        # assembly fast paths behind !go1.28, so 1.27 exercises the same code
+        # as 1.26 and the next toolchain is the one to re-check.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
           - 1.26
+          - 1.27
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/latestdepth4.yml
+++ b/.github/workflows/latestdepth4.yml
@@ -27,13 +27,14 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 is held back until
-        # bytedance/sonic >= v1.15.0 is picked up - v1.14.1 gates GoMapIterator
-        # behind !go1.26, which breaks the eino and hertz builds.
+        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
+        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
+          - 1.26
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/latestdepth4.yml
+++ b/.github/workflows/latestdepth4.yml
@@ -27,17 +27,14 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 and 1.27 joined once
-        # bytedance/sonic reached v1.15.x - v1.14.1 gated GoMapIterator behind
-        # !go1.26, which broke the eino and hertz builds. sonic keeps its
-        # assembly fast paths behind !go1.28, so 1.27 exercises the same code
-        # as 1.26 and the next toolchain is the one to re-check.
+        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
+        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
           - 1.26
-          - 1.27
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/latestdepth4.yml
+++ b/.github/workflows/latestdepth4.yml
@@ -24,6 +24,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      # One flaky Go version should not cancel the others; the matrix is
+      # wide enough now that a cancelled column hides real signal.
+      fail-fast: false
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade

--- a/.github/workflows/latestdepth4.yml
+++ b/.github/workflows/latestdepth4.yml
@@ -27,14 +27,17 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
-        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
-        # !go1.26, which broke the eino and hertz builds.
+        # path that users on 1.24 rely on. Go 1.26 and 1.27 joined once
+        # bytedance/sonic reached v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds. sonic keeps its
+        # assembly fast paths behind !go1.28, so 1.27 exercises the same code
+        # as 1.26 and the next toolchain is the one to re-check.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
           - 1.26
+          - 1.27
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/plugins1.yml
+++ b/.github/workflows/plugins1.yml
@@ -33,13 +33,14 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 is held back until
-        # bytedance/sonic >= v1.15.0 is picked up - v1.14.1 gates GoMapIterator
-        # behind !go1.26, which breaks the eino and hertz builds.
+        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
+        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
+          - 1.26
         os:
           - ubuntu-latest
     steps:

--- a/.github/workflows/plugins1.yml
+++ b/.github/workflows/plugins1.yml
@@ -33,14 +33,17 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
-        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
-        # !go1.26, which broke the eino and hertz builds.
+        # path that users on 1.24 rely on. Go 1.26 and 1.27 joined once
+        # bytedance/sonic reached v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds. sonic keeps its
+        # assembly fast paths behind !go1.28, so 1.27 exercises the same code
+        # as 1.26 and the next toolchain is the one to re-check.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
           - 1.26
+          - 1.27
         os:
           - ubuntu-latest
     steps:

--- a/.github/workflows/plugins1.yml
+++ b/.github/workflows/plugins1.yml
@@ -30,6 +30,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      # One flaky Go version should not cancel the others; the matrix is
+      # wide enough now that a cancelled column hides real signal.
+      fail-fast: false
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade

--- a/.github/workflows/plugins1.yml
+++ b/.github/workflows/plugins1.yml
@@ -33,17 +33,14 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 and 1.27 joined once
-        # bytedance/sonic reached v1.15.x - v1.14.1 gated GoMapIterator behind
-        # !go1.26, which broke the eino and hertz builds. sonic keeps its
-        # assembly fast paths behind !go1.28, so 1.27 exercises the same code
-        # as 1.26 and the next toolchain is the one to re-check.
+        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
+        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
           - 1.26
-          - 1.27
         os:
           - ubuntu-latest
     steps:

--- a/.github/workflows/plugins2.yml
+++ b/.github/workflows/plugins2.yml
@@ -29,14 +29,17 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
-        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
-        # !go1.26, which broke the eino and hertz builds.
+        # path that users on 1.24 rely on. Go 1.26 and 1.27 joined once
+        # bytedance/sonic reached v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds. sonic keeps its
+        # assembly fast paths behind !go1.28, so 1.27 exercises the same code
+        # as 1.26 and the next toolchain is the one to re-check.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
           - 1.26
+          - 1.27
         os:
           - ubuntu-latest
     steps:

--- a/.github/workflows/plugins2.yml
+++ b/.github/workflows/plugins2.yml
@@ -29,17 +29,14 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 and 1.27 joined once
-        # bytedance/sonic reached v1.15.x - v1.14.1 gated GoMapIterator behind
-        # !go1.26, which broke the eino and hertz builds. sonic keeps its
-        # assembly fast paths behind !go1.28, so 1.27 exercises the same code
-        # as 1.26 and the next toolchain is the one to re-check.
+        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
+        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
           - 1.26
-          - 1.27
         os:
           - ubuntu-latest
     steps:

--- a/.github/workflows/plugins2.yml
+++ b/.github/workflows/plugins2.yml
@@ -26,6 +26,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      # One flaky Go version should not cancel the others; the matrix is
+      # wide enough now that a cancelled column hides real signal.
+      fail-fast: false
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade

--- a/.github/workflows/plugins2.yml
+++ b/.github/workflows/plugins2.yml
@@ -29,13 +29,14 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 is held back until
-        # bytedance/sonic >= v1.15.0 is picked up - v1.14.1 gates GoMapIterator
-        # behind !go1.26, which breaks the eino and hertz builds.
+        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
+        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
+          - 1.26
         os:
           - ubuntu-latest
     steps:

--- a/.github/workflows/plugins3.yml
+++ b/.github/workflows/plugins3.yml
@@ -27,17 +27,14 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 and 1.27 joined once
-        # bytedance/sonic reached v1.15.x - v1.14.1 gated GoMapIterator behind
-        # !go1.26, which broke the eino and hertz builds. sonic keeps its
-        # assembly fast paths behind !go1.28, so 1.27 exercises the same code
-        # as 1.26 and the next toolchain is the one to re-check.
+        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
+        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
           - 1.26
-          - 1.27
         os:
           - ubuntu-latest
     steps:

--- a/.github/workflows/plugins3.yml
+++ b/.github/workflows/plugins3.yml
@@ -27,13 +27,14 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 is held back until
-        # bytedance/sonic >= v1.15.0 is picked up - v1.14.1 gates GoMapIterator
-        # behind !go1.26, which breaks the eino and hertz builds.
+        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
+        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
+          - 1.26
         os:
           - ubuntu-latest
     steps:

--- a/.github/workflows/plugins3.yml
+++ b/.github/workflows/plugins3.yml
@@ -24,6 +24,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      # One flaky Go version should not cancel the others; the matrix is
+      # wide enough now that a cancelled column hides real signal.
+      fail-fast: false
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade

--- a/.github/workflows/plugins3.yml
+++ b/.github/workflows/plugins3.yml
@@ -27,14 +27,17 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
-        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
-        # !go1.26, which broke the eino and hertz builds.
+        # path that users on 1.24 rely on. Go 1.26 and 1.27 joined once
+        # bytedance/sonic reached v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds. sonic keeps its
+        # assembly fast paths behind !go1.28, so 1.27 exercises the same code
+        # as 1.26 and the next toolchain is the one to re-check.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
           - 1.26
+          - 1.27
         os:
           - ubuntu-latest
     steps:

--- a/.github/workflows/plugins4.yml
+++ b/.github/workflows/plugins4.yml
@@ -27,17 +27,14 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 and 1.27 joined once
-        # bytedance/sonic reached v1.15.x - v1.14.1 gated GoMapIterator behind
-        # !go1.26, which broke the eino and hertz builds. sonic keeps its
-        # assembly fast paths behind !go1.28, so 1.27 exercises the same code
-        # as 1.26 and the next toolchain is the one to re-check.
+        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
+        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
           - 1.26
-          - 1.27
         os:
           - ubuntu-latest
     steps:

--- a/.github/workflows/plugins4.yml
+++ b/.github/workflows/plugins4.yml
@@ -27,13 +27,14 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 is held back until
-        # bytedance/sonic >= v1.15.0 is picked up - v1.14.1 gates GoMapIterator
-        # behind !go1.26, which breaks the eino and hertz builds.
+        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
+        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
+          - 1.26
         os:
           - ubuntu-latest
     steps:

--- a/.github/workflows/plugins4.yml
+++ b/.github/workflows/plugins4.yml
@@ -24,6 +24,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      # One flaky Go version should not cancel the others; the matrix is
+      # wide enough now that a cancelled column hides real signal.
+      fail-fast: false
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade

--- a/.github/workflows/plugins4.yml
+++ b/.github/workflows/plugins4.yml
@@ -27,14 +27,17 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
-        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
-        # !go1.26, which broke the eino and hertz builds.
+        # path that users on 1.24 rely on. Go 1.26 and 1.27 joined once
+        # bytedance/sonic reached v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds. sonic keeps its
+        # assembly fast paths behind !go1.28, so 1.27 exercises the same code
+        # as 1.26 and the next toolchain is the one to re-check.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
           - 1.26
+          - 1.27
         os:
           - ubuntu-latest
     steps:

--- a/.github/workflows/util-genai.yml
+++ b/.github/workflows/util-genai.yml
@@ -26,17 +26,14 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 and 1.27 joined once
-        # bytedance/sonic reached v1.15.x - v1.14.1 gated GoMapIterator behind
-        # !go1.26, which broke the eino and hertz builds. sonic keeps its
-        # assembly fast paths behind !go1.28, so 1.27 exercises the same code
-        # as 1.26 and the next toolchain is the one to re-check.
+        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
+        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
           - 1.26
-          - 1.27
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/util-genai.yml
+++ b/.github/workflows/util-genai.yml
@@ -26,14 +26,17 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
-        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
-        # !go1.26, which broke the eino and hertz builds.
+        # path that users on 1.24 rely on. Go 1.26 and 1.27 joined once
+        # bytedance/sonic reached v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds. sonic keeps its
+        # assembly fast paths behind !go1.28, so 1.27 exercises the same code
+        # as 1.26 and the next toolchain is the one to re-check.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
           - 1.26
+          - 1.27
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/util-genai.yml
+++ b/.github/workflows/util-genai.yml
@@ -26,13 +26,14 @@ jobs:
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade
-        # path that users on 1.24 rely on. Go 1.26 is held back until
-        # bytedance/sonic >= v1.15.0 is picked up - v1.14.1 gates GoMapIterator
-        # behind !go1.26, which breaks the eino and hertz builds.
+        # path that users on 1.24 rely on. Go 1.26 joins the matrix now that
+        # bytedance/sonic is on v1.15.x - v1.14.1 gated GoMapIterator behind
+        # !go1.26, which broke the eino and hertz builds.
         # See https://github.com/bytedance/sonic/issues/895
         go_version:
           - 1.24
           - 1.25
+          - 1.26
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/util-genai.yml
+++ b/.github/workflows/util-genai.yml
@@ -23,6 +23,9 @@ jobs:
     env:
       GOFLAGS: -mod=mod
     strategy:
+      # One flaky Go version should not cancel the others; the matrix is
+      # wide enough now that a cancelled column hides real signal.
+      fail-fast: false
       matrix:
         # Go 1.24 is kept deliberately: modules declare `go 1.25.0` (required by
         # OTel >= 1.42), so a 1.24 runner exercises the GOTOOLCHAIN=auto upgrade

--- a/docs/user/compatibility.md
+++ b/docs/user/compatibility.md
@@ -32,31 +32,24 @@ This project is tested on the following systems.
 | Ubuntu   | 1.24       | amd64        |
 | Ubuntu   | 1.25       | amd64        |
 | Ubuntu   | 1.26       | amd64        |
-| Ubuntu   | 1.27       | amd64        |
 | Ubuntu   | 1.24       | 386          |
 | Ubuntu   | 1.25       | 386          |
 | Ubuntu   | 1.26       | 386          |
-| Ubuntu   | 1.27       | 386          |
 | Ubuntu   | 1.24       | arm64        |
 | Ubuntu   | 1.25       | arm64        |
 | Ubuntu   | 1.26       | arm64        |
-| Ubuntu   | 1.27       | arm64        |
 | macOS 13 | 1.24       | amd64        |
 | macOS 13 | 1.25       | amd64        |
 | macOS 13 | 1.26       | amd64        |
-| macOS 13 | 1.27       | amd64        |
 | macOS    | 1.24       | arm64        |
 | macOS    | 1.25       | arm64        |
 | macOS    | 1.26       | arm64        |
-| macOS    | 1.27       | arm64        |
 | Windows  | 1.24       | amd64        |
 | Windows  | 1.25       | amd64        |
 | Windows  | 1.26       | amd64        |
-| Windows  | 1.27       | amd64        |
 | Windows  | 1.24       | 386          |
 | Windows  | 1.25       | 386          |
 | Windows  | 1.26       | 386          |
-| Windows  | 1.27       | 386          |
 
 While this project should work for other systems, no compatibility guarantees
 are made for those systems currently.

--- a/docs/user/compatibility.md
+++ b/docs/user/compatibility.md
@@ -31,18 +31,25 @@ This project is tested on the following systems.
 | -------- | ---------- | ------------ |
 | Ubuntu   | 1.24       | amd64        |
 | Ubuntu   | 1.25       | amd64        |
+| Ubuntu   | 1.26       | amd64        |
 | Ubuntu   | 1.24       | 386          |
 | Ubuntu   | 1.25       | 386          |
+| Ubuntu   | 1.26       | 386          |
 | Ubuntu   | 1.24       | arm64        |
 | Ubuntu   | 1.25       | arm64        |
+| Ubuntu   | 1.26       | arm64        |
 | macOS 13 | 1.24       | amd64        |
 | macOS 13 | 1.25       | amd64        |
+| macOS 13 | 1.26       | amd64        |
 | macOS    | 1.24       | arm64        |
 | macOS    | 1.25       | arm64        |
+| macOS    | 1.26       | arm64        |
 | Windows  | 1.24       | amd64        |
 | Windows  | 1.25       | amd64        |
+| Windows  | 1.26       | amd64        |
 | Windows  | 1.24       | 386          |
 | Windows  | 1.25       | 386          |
+| Windows  | 1.26       | 386          |
 
 While this project should work for other systems, no compatibility guarantees
 are made for those systems currently.

--- a/docs/user/compatibility.md
+++ b/docs/user/compatibility.md
@@ -32,24 +32,31 @@ This project is tested on the following systems.
 | Ubuntu   | 1.24       | amd64        |
 | Ubuntu   | 1.25       | amd64        |
 | Ubuntu   | 1.26       | amd64        |
+| Ubuntu   | 1.27       | amd64        |
 | Ubuntu   | 1.24       | 386          |
 | Ubuntu   | 1.25       | 386          |
 | Ubuntu   | 1.26       | 386          |
+| Ubuntu   | 1.27       | 386          |
 | Ubuntu   | 1.24       | arm64        |
 | Ubuntu   | 1.25       | arm64        |
 | Ubuntu   | 1.26       | arm64        |
+| Ubuntu   | 1.27       | arm64        |
 | macOS 13 | 1.24       | amd64        |
 | macOS 13 | 1.25       | amd64        |
 | macOS 13 | 1.26       | amd64        |
+| macOS 13 | 1.27       | amd64        |
 | macOS    | 1.24       | arm64        |
 | macOS    | 1.25       | arm64        |
 | macOS    | 1.26       | arm64        |
+| macOS    | 1.27       | arm64        |
 | Windows  | 1.24       | amd64        |
 | Windows  | 1.25       | amd64        |
 | Windows  | 1.26       | amd64        |
+| Windows  | 1.27       | amd64        |
 | Windows  | 1.24       | 386          |
 | Windows  | 1.25       | 386          |
 | Windows  | 1.26       | 386          |
+| Windows  | 1.27       | 386          |
 
 While this project should work for other systems, no compatibility guarantees
 are made for those systems currently.

--- a/docs/zh/user/compatibility.md
+++ b/docs/zh/user/compatibility.md
@@ -24,24 +24,31 @@
 | Ubuntu   | 1.24    | amd64 |
 | Ubuntu   | 1.25    | amd64 |
 | Ubuntu   | 1.26    | amd64 |
+| Ubuntu   | 1.27    | amd64 |
 | Ubuntu   | 1.24    | 386   |
 | Ubuntu   | 1.25    | 386   |
 | Ubuntu   | 1.26    | 386   |
+| Ubuntu   | 1.27    | 386   |
 | Ubuntu   | 1.24    | arm64 |
 | Ubuntu   | 1.25    | arm64 |
 | Ubuntu   | 1.26    | arm64 |
+| Ubuntu   | 1.27    | arm64 |
 | macOS 13 | 1.24    | amd64 |
 | macOS 13 | 1.25    | amd64 |
 | macOS 13 | 1.26    | amd64 |
+| macOS 13 | 1.27    | amd64 |
 | macOS    | 1.24    | arm64 |
 | macOS    | 1.25    | arm64 |
 | macOS    | 1.26    | arm64 |
+| macOS    | 1.27    | arm64 |
 | Windows  | 1.24    | amd64 |
 | Windows  | 1.25    | amd64 |
 | Windows  | 1.26    | amd64 |
+| Windows  | 1.27    | amd64 |
 | Windows  | 1.24    | 386   |
 | Windows  | 1.25    | 386   |
 | Windows  | 1.26    | 386   |
+| Windows  | 1.27    | 386   |
 
 虽然该项目应该适用于其他系统，但目前不对这些系统提供兼容性保证。
 

--- a/docs/zh/user/compatibility.md
+++ b/docs/zh/user/compatibility.md
@@ -24,31 +24,24 @@
 | Ubuntu   | 1.24    | amd64 |
 | Ubuntu   | 1.25    | amd64 |
 | Ubuntu   | 1.26    | amd64 |
-| Ubuntu   | 1.27    | amd64 |
 | Ubuntu   | 1.24    | 386   |
 | Ubuntu   | 1.25    | 386   |
 | Ubuntu   | 1.26    | 386   |
-| Ubuntu   | 1.27    | 386   |
 | Ubuntu   | 1.24    | arm64 |
 | Ubuntu   | 1.25    | arm64 |
 | Ubuntu   | 1.26    | arm64 |
-| Ubuntu   | 1.27    | arm64 |
 | macOS 13 | 1.24    | amd64 |
 | macOS 13 | 1.25    | amd64 |
 | macOS 13 | 1.26    | amd64 |
-| macOS 13 | 1.27    | amd64 |
 | macOS    | 1.24    | arm64 |
 | macOS    | 1.25    | arm64 |
 | macOS    | 1.26    | arm64 |
-| macOS    | 1.27    | arm64 |
 | Windows  | 1.24    | amd64 |
 | Windows  | 1.25    | amd64 |
 | Windows  | 1.26    | amd64 |
-| Windows  | 1.27    | amd64 |
 | Windows  | 1.24    | 386   |
 | Windows  | 1.25    | 386   |
 | Windows  | 1.26    | 386   |
-| Windows  | 1.27    | 386   |
 
 虽然该项目应该适用于其他系统，但目前不对这些系统提供兼容性保证。
 

--- a/docs/zh/user/compatibility.md
+++ b/docs/zh/user/compatibility.md
@@ -23,18 +23,25 @@
 | -------- | ------- | ----- |
 | Ubuntu   | 1.24    | amd64 |
 | Ubuntu   | 1.25    | amd64 |
+| Ubuntu   | 1.26    | amd64 |
 | Ubuntu   | 1.24    | 386   |
 | Ubuntu   | 1.25    | 386   |
+| Ubuntu   | 1.26    | 386   |
 | Ubuntu   | 1.24    | arm64 |
 | Ubuntu   | 1.25    | arm64 |
+| Ubuntu   | 1.26    | arm64 |
 | macOS 13 | 1.24    | amd64 |
 | macOS 13 | 1.25    | amd64 |
+| macOS 13 | 1.26    | amd64 |
 | macOS    | 1.24    | arm64 |
 | macOS    | 1.25    | arm64 |
+| macOS    | 1.26    | arm64 |
 | Windows  | 1.24    | amd64 |
 | Windows  | 1.25    | amd64 |
+| Windows  | 1.26    | amd64 |
 | Windows  | 1.24    | 386   |
 | Windows  | 1.25    | 386   |
+| Windows  | 1.26    | 386   |
 
 虽然该项目应该适用于其他系统，但目前不对这些系统提供兼容性保证。
 

--- a/example/eino/go.mod
+++ b/example/eino/go.mod
@@ -34,8 +34,8 @@ require (
 	github.com/PuerkitoBio/goquery v1.10.3 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.14.1 // indirect
-	github.com/bytedance/sonic/loader v0.3.0 // indirect
+	github.com/bytedance/sonic v1.15.3 // indirect
+	github.com/bytedance/sonic/loader v0.5.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/cloudwego/eino-ext/components/document/loader/file v0.0.0-20250225083118-fd27d80f189c

--- a/pkg/rules/eino/go.mod
+++ b/pkg/rules/eino/go.mod
@@ -6,7 +6,7 @@ replace github.com/alibaba/loongsuite-go/pkg => ../../../pkg
 
 require (
 	github.com/alibaba/loongsuite-go/pkg v0.0.0-20250707083332-bbadcb2d53b5
-	github.com/bytedance/sonic v1.14.1
+	github.com/bytedance/sonic v1.15.3
 	github.com/cloudwego/eino v0.7.13
 	github.com/cloudwego/eino-ext/components/model/ark v0.1.61
 	github.com/cloudwego/eino-ext/components/model/claude v0.1.13
@@ -39,7 +39,7 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic/loader v0.3.0 // indirect
+	github.com/bytedance/sonic/loader v0.5.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/cloudwego/eino-ext/libs/acl/openai v0.1.11 // indirect

--- a/pkg/rules/gin/go.mod
+++ b/pkg/rules/gin/go.mod
@@ -12,8 +12,8 @@ require (
 
 require (
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.14.1 // indirect
-	github.com/bytedance/sonic/loader v0.3.0 // indirect
+	github.com/bytedance/sonic v1.15.3 // indirect
+	github.com/bytedance/sonic/loader v0.5.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect

--- a/pkg/rules/hertz/client/go.mod
+++ b/pkg/rules/hertz/client/go.mod
@@ -13,8 +13,8 @@ require (
 
 require (
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.14.1 // indirect
-	github.com/bytedance/sonic/loader v0.3.0 // indirect
+	github.com/bytedance/sonic v1.15.3 // indirect
+	github.com/bytedance/sonic/loader v0.5.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/cloudwego/gopkg v0.1.4 // indirect

--- a/pkg/rules/hertz/server/go.mod
+++ b/pkg/rules/hertz/server/go.mod
@@ -13,8 +13,8 @@ require (
 
 require (
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.14.1 // indirect
-	github.com/bytedance/sonic/loader v0.3.0 // indirect
+	github.com/bytedance/sonic v1.15.3 // indirect
+	github.com/bytedance/sonic/loader v0.5.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/cloudwego/gopkg v0.1.4 // indirect

--- a/pkg/rules/kitex/go.mod
+++ b/pkg/rules/kitex/go.mod
@@ -16,7 +16,7 @@ require (
 require (
 	github.com/apache/thrift v0.13.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/choleraehyq/pid v0.0.21 // indirect
+	github.com/choleraehyq/pid v0.0.24 // indirect
 	github.com/cloudwego/fastpb v0.0.5 // indirect
 	github.com/cloudwego/frugal v0.2.5 // indirect
 	github.com/cloudwego/gopkg v0.1.4 // indirect

--- a/pkg/rules/meguminnnnnnnnn-openai/go.mod
+++ b/pkg/rules/meguminnnnnnnnn-openai/go.mod
@@ -10,15 +10,16 @@ require (
 )
 
 require (
-	github.com/bytedance/sonic v1.14.0 // indirect
-	github.com/bytedance/sonic/loader v0.3.0 // indirect
+	github.com/bytedance/gopkg v0.1.3 // indirect
+	github.com/bytedance/sonic v1.15.3 // indirect
+	github.com/bytedance/sonic/loader v0.5.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/cloudwego/base64x v0.1.5 // indirect
+	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/evanphx/json-patch v0.5.2 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/pkg/rules/newapi/go.mod
+++ b/pkg/rules/newapi/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/abema/go-mp4 v1.4.1 // indirect
 	github.com/boombuler/barcode v1.1.0 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.14.1 // indirect
-	github.com/bytedance/sonic/loader v0.3.0 // indirect
+	github.com/bytedance/sonic v1.15.3 // indirect
+	github.com/bytedance/sonic/loader v0.5.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -6,8 +6,8 @@ require github.com/gin-gonic/gin v1.10.1
 
 require (
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.14.1 // indirect
-	github.com/bytedance/sonic/loader v0.3.0 // indirect
+	github.com/bytedance/sonic v1.15.3 // indirect
+	github.com/bytedance/sonic/loader v0.5.2 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect

--- a/test/eino/v0.7.13/go.mod
+++ b/test/eino/v0.7.13/go.mod
@@ -44,8 +44,8 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.14.1 // indirect
-	github.com/bytedance/sonic/loader v0.3.0 // indirect
+	github.com/bytedance/sonic v1.15.3 // indirect
+	github.com/bytedance/sonic/loader v0.5.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/cloudwego/eino-ext/libs/acl/openai v0.1.11 // indirect

--- a/test/gin/go.mod
+++ b/test/gin/go.mod
@@ -17,8 +17,8 @@ require (
 require (
 	github.com/alibaba/loongsuite-go/pkg v0.0.0-20251031085506-d38edbf99f97 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.14.1 // indirect
-	github.com/bytedance/sonic/loader v0.3.0 // indirect
+	github.com/bytedance/sonic v1.15.3 // indirect
+	github.com/bytedance/sonic/loader v0.5.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/test/hertz/v0.10.1/go.mod
+++ b/test/hertz/v0.10.1/go.mod
@@ -18,8 +18,8 @@ require (
 require (
 	github.com/alibaba/loongsuite-go/pkg v0.0.0-20251031085506-d38edbf99f97 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.14.1 // indirect
-	github.com/bytedance/sonic/loader v0.3.0 // indirect
+	github.com/bytedance/sonic v1.15.3 // indirect
+	github.com/bytedance/sonic/loader v0.5.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/cloudwego/gopkg v0.1.4 // indirect

--- a/test/kitex/v0.5.1/go.mod
+++ b/test/kitex/v0.5.1/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/alibaba/loongsuite-go/pkg v0.0.0-20251031085506-d38edbf99f97 // indirect
 	github.com/bytedance/gopkg v0.0.0-20240711085056-a03554c296f8 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/choleraehyq/pid v0.0.21 // indirect
+	github.com/choleraehyq/pid v0.0.24 // indirect
 	github.com/cloudwego/fastpb v0.0.4 // indirect
 	github.com/cloudwego/frugal v0.2.0 // indirect
 	github.com/cloudwego/gopkg v0.1.0 // indirect

--- a/test/kitex_tests.go
+++ b/test/kitex_tests.go
@@ -24,7 +24,14 @@ func init() {
 		NewGeneralTestCase("kitex-basic-test", kitex_module_name, "", "", "1.18", "", TestKitexBasic),
 		NewGeneralTestCase("kitex-grpc-test", kitex_module_name, "", "", "1.18", "", TestKitexGrpc),
 		NewMuzzleTestCase("kitex-basic-test", kitex_dependency_name, kitex_module_name, "", "", "1.18", "", []string{"test_grpc_kitex.go", "handler.go"}),
-		NewLatestDepthTestCase("kitex-latestdepth-test", kitex_dependency_name, kitex_module_name, "", "v0.15.1", "1.18", "", TestKitexBasic),
+		// Capped at Go 1.25: kitex v0.15.1 requires sonic v1.14.1 and dynamicgo
+		// v0.7.0, and neither builds on Go 1.26 - sonic gates GoMapIterator
+		// behind !go1.26, dynamicgo links against encoding/json internals the
+		// 1.26 linker rejects. Both need an upstream kitex release to move;
+		// forcing newer transitive versions here would test a combination
+		// upstream never shipped. Lift the cap once kitex requires
+		// sonic >= v1.15.0 and dynamicgo >= v0.9.0.
+		NewLatestDepthTestCase("kitex-latestdepth-test", kitex_dependency_name, kitex_module_name, "", "v0.15.1", "1.18", "1.25", TestKitexBasic),
 	)
 }
 

--- a/test/kitex_tests.go
+++ b/test/kitex_tests.go
@@ -24,14 +24,12 @@ func init() {
 		NewGeneralTestCase("kitex-basic-test", kitex_module_name, "", "", "1.18", "", TestKitexBasic),
 		NewGeneralTestCase("kitex-grpc-test", kitex_module_name, "", "", "1.18", "", TestKitexGrpc),
 		NewMuzzleTestCase("kitex-basic-test", kitex_dependency_name, kitex_module_name, "", "", "1.18", "", []string{"test_grpc_kitex.go", "handler.go"}),
-		// Capped at Go 1.25: kitex v0.15.1 requires sonic v1.14.1 and dynamicgo
-		// v0.7.0, and neither builds on Go 1.26 - sonic gates GoMapIterator
-		// behind !go1.26, dynamicgo links against encoding/json internals the
-		// 1.26 linker rejects. Both need an upstream kitex release to move;
-		// forcing newer transitive versions here would test a combination
-		// upstream never shipped. Lift the cap once kitex requires
-		// sonic >= v1.15.0 and dynamicgo >= v0.9.0.
-		NewLatestDepthTestCase("kitex-latestdepth-test", kitex_dependency_name, kitex_module_name, "", "v0.15.1", "1.18", "1.25", TestKitexBasic),
+		// Capped at kitex v0.16.3: the ceiling exists to keep this test on a
+		// release we have actually verified. v0.16.0 is the first that
+		// requires sonic v1.15.0 and dynamicgo v0.8.0, which is what makes
+		// it build on Go 1.26 - v0.15.x pulls sonic v1.14.1 and dynamicgo
+		// v0.7.0 and does not.
+		NewLatestDepthTestCase("kitex-latestdepth-test", kitex_dependency_name, kitex_module_name, "", "v0.16.3", "1.18", "", TestKitexBasic),
 	)
 }
 

--- a/test/meguminnnnnnnnn-openai/v0.0.0-20250821095446/go.mod
+++ b/test/meguminnnnnnnnn-openai/v0.0.0-20250821095446/go.mod
@@ -16,16 +16,17 @@ require (
 
 require (
 	github.com/alibaba/loongsuite-go/pkg v0.0.0-00010101000000-000000000000 // indirect
-	github.com/bytedance/sonic v1.14.0 // indirect
-	github.com/bytedance/sonic/loader v0.3.0 // indirect
+	github.com/bytedance/gopkg v0.1.3 // indirect
+	github.com/bytedance/sonic v1.15.3 // indirect
+	github.com/bytedance/sonic/loader v0.5.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/cloudwego/base64x v0.1.5 // indirect
+	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/evanphx/json-patch v0.5.2 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/test/newapi/v0.12.8/go.mod
+++ b/test/newapi/v0.12.8/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/abema/go-mp4 v1.4.1 // indirect
 	github.com/boombuler/barcode v1.1.0 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.14.1 // indirect
-	github.com/bytedance/sonic/loader v0.3.0 // indirect
+	github.com/bytedance/sonic v1.15.3 // indirect
+	github.com/bytedance/sonic/loader v0.5.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/test/world/go.mod
+++ b/test/world/go.mod
@@ -62,8 +62,8 @@ require (
 	github.com/bits-and-blooms/bitset v1.2.0 // indirect
 	github.com/bytedance/go-tagexpr/v2 v2.9.2 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.14.1 // indirect
-	github.com/bytedance/sonic/loader v0.3.0 // indirect
+	github.com/bytedance/sonic v1.15.3 // indirect
+	github.com/bytedance/sonic/loader v0.5.2 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/cloudwego/eino-ext/libs/acl/openai v0.0.0-20250626133421-3c142631c961 // indirect


### PR DESCRIPTION
## Summary

Unblocks Go 1.26 for this tree. Two dependencies gate their code behind Go build tags and have to move together, and the CI matrix gains 1.26 to prove it.

| Dependency | Before | After | Blocks |
| --- | --- | --- | --- |
| `github.com/bytedance/sonic` | v1.14.1 (v1.14.0 in one module) | **v1.15.3** | eino, gin, hertz, newapi |
| `github.com/bytedance/sonic/loader` | v0.3.0 | **v0.5.2** | (moves with sonic) |
| `github.com/choleraehyq/pid` | v0.0.21 | **v0.0.24** | kitex |

Go 1.27 was tried and reverted — see below. Commits are separable if you want to land less.

## sonic

v1.14.x guards its `GoMapIterator` stub behind a `!go1.26` build tag, so anything reaching it fails on a Go 1.26 toolchain:

```
$ go build ./...          # pkg/rules/eino, Go 1.26.1
# github.com/bytedance/sonic/internal/rt
.../sonic@v1.14.1/internal/rt/stubs.go:33:22: undefined: GoMapIterator
```

Not only a CI concern: `pkg/rules/eino`, `pkg/rules/gin` and both hertz rules ship with that pin, so users already on Go 1.26 hit it today. v1.15.0 restored the symbol ([sonic#895](https://github.com/bytedance/sonic/issues/895)); v1.15.3 is current.

## pid

Same shape, found by actually running the plugin suites against the wider matrix. v0.0.21 carries assembly a Go 1.26 toolchain rejects:

```
choleraehyq/pid@v0.0.21/goid_go1.5_amd64.s:27: expected pseudo-register; found R14
```

kitex reaches it through `kitex/pkg/utils`, breaking both `pkg/rules/kitex` and the kitex fixture. Neither lists sonic, which is why a sweep of go.mod files carrying `bytedance/sonic` missed them. v0.0.22 is the first release that assembles under 1.26.

## Why Go 1.27 is not here

The sonic reasoning held — v1.15.x gates its fast paths at `!go1.28`, so 1.27 compiles the same code 1.26 does — but sonic was not the only blocker, and the other two are not fixable by a version bump:

- **pid has no 1.27 release.** v0.0.24 fails 1.27 with the same assembler error. There is nothing to bump to.
- **dubbo emits an extra `net/http` client span on 1.27**, shifting the indices the RPC assertions read. Plugins1 and latestdepth1 both fail, 1.27 only, with `Expect to be server span, got 3` and `Except client span name to be greet.GreetService/Greet, got POST`. That is an instrumentation question, not a dependency bump.

Keeping 1.27 in the matrix until those are resolved only buys a permanently red column, so the commit that added it is reverted rather than dropped, to keep the finding in the history.

## fail-fast

The default cancelled three of four columns the moment one failed. Plugins2 lost 1.25/1.26/1.27 to a single `sum.golang.org` read error on 1.24; Plugins4 lost 1.24/1.26 the same way. Worse, it **hid a real bug**: the kitex pid breakage on 1.26 never appeared in any log, because every 1.26 job that would have hit it was cancelled by an unrelated network flake in a different column. It was found locally instead.

Each column now reports its own result. The underlying flakes are checksum-database reads, not code:

```
reading https://sum.golang.org/tile/8/0/x091/984: stream error; INTERNAL_ERROR; received from peer
```

## Scope

Every go.mod carrying sonic moves together — four shipped rules modules plus `newapi` and `meguminnnnnnnnn-openai`, the eino example, and the fixtures those rules are tested against. A fixture left behind reintroduces the failure the rules module just escaped.

Edited with `go mod edit`, not `go mod tidy`: several of these modules are not currently tidy, and tidying would bury a two-line change under unrelated churn. `pkg/rules/meguminnnnnnnnn-openai` gains three transitive floors v1.15.3 requires (`bytedance/gopkg` v0.1.3, `cloudwego/base64x` v0.1.6, `klauspost/cpuid/v2` v2.2.9) — it was the one module still on sonic v1.14.0.

sonic, its loader and pid all still declare `go 1.18`, so **nothing raises the language floor.** The Go 1.25 minimum from #747 is unchanged; this widens what is tested, not what is required. `release.yml` keeps its explicit 1.25 pin. Both compatibility pages gain the matching 1.26 rows, as ef1a8bb did for 1.25.

## Testing

Verified locally on **Go 1.26.1**, re-checked on **1.25.13** for regressions:

| Check | Result |
| --- | --- |
| `go build github.com/bytedance/sonic/...` in all six modules pinning it | ok |
| kitex fixture and `pkg/rules/kitex` (failed on 1.26 before the pid bump) | ok |
| root module build, `go vet ./tool/...` | ok |
| `pkg/rules/eino`, `hertz/client`, `newapi`, `example/eino`, `util-genai` | ok |
| gin, eino, hertz fixtures, built per entrypoint | ok |

Remaining build errors in `pkg/rules/gin`, `hertz/server` and `meguminnnnnnnnn-openai` are the pre-existing ones for preprocessor-injected symbols, unchanged from `main` and confirmed by building those modules at `main` for comparison.
